### PR TITLE
Change base image to elixir:1.13 in docker files

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -16,7 +16,7 @@
 # This should match the version of Alpine that the `elixir:1.14-alpine` image uses
 ARG ALPINE_VERSION=3.16
 
-FROM elixir:1.14-alpine AS builder
+FROM elixir:1.13-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,7 +16,7 @@
 # This should match the version of Alpine that the `elixir:1.13.4-alpine` image uses
 ARG ALPINE_VERSION=3.16
 
-FROM elixir:1.14-alpine AS builder
+FROM elixir:1.13-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,10 +14,6 @@
 
 import Config
 
-config :core, Core.Domain.Ports.Commands, adapter: Core.Adapters.Commands.Worker
-config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
-config :core, Core.Domain.Ports.FunctionStore, adapter: Core.Adapters.FunctionStore.Mnesia
-
 # tell logger to load a LoggerFileBackend processes
 config :logger,
   backends: [:console, {LoggerFileBackend, :info_log}],


### PR DESCRIPTION
Libcluster Gossip strategy is not currently working with otp 25, the base image elixir:1.13 uses otp 24 which has no problems.