### PR TITLE
Functions and Modules names with  underscores

### DIFF
--- a/apps/core/lib/core/schemas/function.ex
+++ b/apps/core/lib/core/schemas/function.ex
@@ -31,7 +31,7 @@ defmodule Core.Schemas.Function do
   @doc false
   def changeset(function, attrs) do
     # only allow valid letters, numbers and underscores in the middle
-    regex = ~r/^[a-zA-Z0-9]([_a-zA-Z0-9]*[a-zA-Z0-9])?$/
+    regex = ~r/^[_a-zA-Z0-9]+$/
     msg = "must contain only alphanumeric characters and underscores"
 
     function

--- a/apps/core/lib/core/schemas/module.ex
+++ b/apps/core/lib/core/schemas/module.ex
@@ -30,7 +30,7 @@ defmodule Core.Schemas.Module do
   @doc false
   def changeset(module, attrs) do
     # only allow valid letters, numbers and underscores in the middle
-    regex = ~r/^[a-zA-Z0-9]([_a-zA-Z0-9]*[a-zA-Z0-9])?$/
+    regex = ~r/^[_a-zA-Z0-9]+$/
     msg = "must contain only alphanumeric characters and underscores"
 
     module

--- a/apps/core/test/core/unit/schema_test.exs
+++ b/apps/core/test/core/unit/schema_test.exs
@@ -1,0 +1,58 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.SchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Schemas.Function
+  alias Core.Schemas.Module
+
+  test "invalid names for module" do
+    test_cases = [
+      "$",
+      "-",
+      " ",
+      "invalid-",
+      "invalid ",
+      "invalid name",
+      "invalid-name",
+      "_ "
+    ]
+
+    for test_case <- test_cases do
+      set = Module.changeset(%Module{}, %{name: test_case})
+
+      assert set.valid? == false
+    end
+  end
+
+  test "invalid names for function" do
+    test_cases = [
+      "$",
+      "-",
+      " ",
+      "invalid-",
+      "invalid ",
+      "invalid name",
+      "invalid-name",
+      "_ "
+    ]
+
+    for test_case <- test_cases do
+      set = Function.changeset(%Function{}, %{name: test_case, code: "some code"})
+
+      assert set.valid? == false
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the regex to accept underscores at start and end of name (and the default module "_" name).