### PR TITLE
Add Event Connectors structures

### DIFF
--- a/apps/core/lib/application.ex
+++ b/apps/core/lib/application.ex
@@ -43,7 +43,8 @@ defmodule Core.Application do
       ## Core Children
       Core.Repo,
       {Cluster.Supervisor, [topologies, [name: Core.ClusterSupervisor]]},
-      {Core.Adapters.Telemetry.Supervisor, []}
+      {Core.Adapters.Telemetry.Supervisor, []},
+      {Core.Adapters.Connectors.Supervisor, []}
     ]
   end
 

--- a/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
+++ b/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
@@ -1,0 +1,27 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Connectors.EventConnectors.Mqtt do
+  use GenServer
+  require Logger
+
+  def start_link(params) do
+    GenServer.start_link(__MODULE__, params)
+  end
+
+  def init(%{function: _function, module: _module, params: %{host: _host, port: _port} = params}) do
+    Logger.info("MQTT Event Connector: started with params #{inspect(params)}")
+    {:ok, params}
+  end
+end

--- a/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
+++ b/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
@@ -24,4 +24,8 @@ defmodule Core.Adapters.Connectors.EventConnectors.Mqtt do
     Logger.info("MQTT Event Connector: started with params #{inspect(params)}")
     {:ok, params}
   end
+
+  def handle_call(:any, _from, params) do
+    {:reply, :ok, params}
+  end
 end

--- a/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
+++ b/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 defmodule Core.Adapters.Connectors.EventConnectors.Mqtt do
+  @moduledoc """
+  Event Connector for MQTT messages.
+  """
   use GenServer
   require Logger
 

--- a/apps/core/lib/core/adapters/connectors/manager.ex
+++ b/apps/core/lib/core/adapters/connectors/manager.ex
@@ -1,0 +1,16 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Connectors.Manager do
+end

--- a/apps/core/lib/core/adapters/connectors/manager.ex
+++ b/apps/core/lib/core/adapters/connectors/manager.ex
@@ -36,11 +36,20 @@ defmodule Core.Adapters.Connectors.Manager do
       end
 
     case result do
-      {:ok, pid} -> ManagerStore.insert(function, module, pid)
-      _ -> nil
-    end
+      {:ok, pid} ->
+        ManagerStore.insert(function, module, pid)
+        :ok
 
-    result
+      {:ok, pid, _info} ->
+        ManagerStore.insert(function, module, pid)
+        :ok
+
+      :ignore ->
+        {:error, :ignore}
+
+      {:error, err} ->
+        {:error, err}
+    end
   end
 
   @impl true
@@ -55,6 +64,7 @@ defmodule Core.Adapters.Connectors.Manager do
         end)
 
         ManagerStore.delete(function, module)
+        :ok
     end
   end
 end

--- a/apps/core/lib/core/adapters/connectors/manager.ex
+++ b/apps/core/lib/core/adapters/connectors/manager.ex
@@ -30,7 +30,7 @@ defmodule Core.Adapters.Connectors.Manager do
       case event_type do
         "mqtt" ->
           DynamicSupervisor.start_child(
-            Core.Adapters.Connectors.Supervisor,
+            Core.Adapters.Connectors.DynamicSupervisor,
             {EventConnectors.Mqtt, %{function: function, module: module, params: params}}
           )
       end
@@ -51,7 +51,7 @@ defmodule Core.Adapters.Connectors.Manager do
 
       pids ->
         Enum.each(pids, fn pid ->
-          DynamicSupervisor.terminate_child(Core.Adapters.Conectors.Supervisor, pid)
+          DynamicSupervisor.terminate_child(Core.Adapters.Connectors.DynamicSupervisor, pid)
         end)
 
         ManagerStore.delete(function, module)

--- a/apps/core/lib/core/adapters/connectors/manager_store.ex
+++ b/apps/core/lib/core/adapters/connectors/manager_store.ex
@@ -29,7 +29,7 @@ defmodule Core.Adapters.Connectors.ManagerStore do
     key = module <> "/" <> function
 
     case :ets.lookup(@ets_table, key) do
-      [{^key, pids}] -> pids
+      [{^key, _pid} | _] = res -> Enum.map(res, fn {_, pid} -> pid end)
       [] -> :not_found
     end
   end
@@ -53,7 +53,7 @@ defmodule Core.Adapters.Connectors.ManagerStore do
 
   @impl true
   def init(_args) do
-    table = :ets.new(@ets_table, [:set, :named_table, :protected])
+    table = :ets.new(@ets_table, [:bag, :named_table, :protected])
     Logger.info("Connectors ETS Server: started")
     {:ok, table}
   end

--- a/apps/core/lib/core/adapters/connectors/manager_store.ex
+++ b/apps/core/lib/core/adapters/connectors/manager_store.ex
@@ -1,0 +1,73 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Connectors.ManagerStore do
+  @moduledoc """
+  The cache for Event Connectors PIDs.
+  When a function is connected to an event, the pid for the corresponding Event Connector is stored here, using `module/function` as key.
+  When a function is deleted or disconnected from its events, the entry is removed.
+  """
+  use GenServer, restart: :permanent
+  require Logger
+
+  @connectors_ets_server :connectors_ets_server
+  @ets_table :connectors_manager_functions
+
+  @spec get(String.t(), String.t()) :: [pid()] | :not_found
+  def get(function, module) do
+    key = module <> "/" <> function
+
+    case :ets.lookup(@ets_table, key) do
+      [{^key, pids}] -> pids
+      [] -> :not_found
+    end
+  end
+
+  @spec insert(String.t(), String.t(), pid()) :: {:ok, {String.t(), pid}}
+  def insert(function, module, pid) do
+    key = module <> "/" <> function
+    GenServer.call(@connectors_ets_server, {:insert, key, pid})
+  end
+
+  @spec delete(String.t(), String.t()) :: {:ok, String.t()}
+  def delete(function, module) do
+    key = module <> "/" <> function
+    GenServer.call(@connectors_ets_server, {:delete, key})
+  end
+
+  # Genserver callbacks
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: @connectors_ets_server)
+  end
+
+  @impl true
+  def init(_args) do
+    table = :ets.new(@ets_table, [:set, :named_table, :protected])
+    Logger.info("Connectors ETS Server: started")
+    {:ok, table}
+  end
+
+  @impl true
+  def handle_call({:insert, key, pid}, _from, table) do
+    :ets.insert(table, {key, pid})
+    {:reply, {:ok, {key, pid}}, table}
+  end
+
+  @impl true
+  def handle_call({:delete, key}, _from, table) do
+    :ets.delete(table, key)
+    Logger.info("Connectors ETS Server: deleted #{key}")
+    {:reply, {:ok, key}, table}
+  end
+end

--- a/apps/core/lib/core/adapters/connectors/supervisor.ex
+++ b/apps/core/lib/core/adapters/connectors/supervisor.ex
@@ -1,0 +1,41 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Connectors.Supervisor do
+  @moduledoc """
+    Implements Supervisor behaviour; starts the Connectors Manager ETS server and the DynamicSupervisor used to handle Event Connectors.
+  """
+  use Supervisor
+  require Logger
+
+  def start_link(args) do
+    Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    Logger.info("Connectors Supervisor: started")
+
+    children = [
+      {Core.Adapters.Connectors.ManagerStore, []},
+      {DynamicSupervisor,
+       strategy: :one_for_one,
+       max_restarts: 5,
+       max_seconds: 5,
+       name: Core.Adapters.Connectors.DynamicSupervisor}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/apps/core/lib/core/adapters/connectors/test.ex
+++ b/apps/core/lib/core/adapters/connectors/test.ex
@@ -12,8 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Mox.defmock(Core.Commands.Mock, for: Core.Domain.Ports.Commands)
-Mox.defmock(Core.Cluster.Mock, for: Core.Domain.Ports.Cluster)
-Mox.defmock(Core.FunctionStore.Mock, for: Core.Domain.Ports.FunctionStore)
-Mox.defmock(Core.Telemetry.Metrics.Mock, for: Core.Domain.Ports.Telemetry.Metrics)
-Mox.defmock(Core.Connectors.Manager.Mock, for: Core.Domain.Ports.Connectors.Manager)
+defmodule Core.Adapters.Connectors.Test do
+  @moduledoc false
+
+  @behaviour Core.Domain.Ports.Connectors.Manager
+
+  @impl true
+  def connect(_function_signature, _event) do
+    :ok
+  end
+
+  @impl true
+  def disconnect(_function_signature) do
+    :ok
+  end
+end

--- a/apps/core/lib/core/domain/ports/connectors/manager.ex
+++ b/apps/core/lib/core/domain/ports/connectors/manager.ex
@@ -1,0 +1,35 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Ports.Connectors.Manager do
+  @moduledoc """
+  Port for managing Event Connectors.
+  """
+  @type function_signature :: %{
+          name: String.t(),
+          module: String.t()
+        }
+
+  @type event :: map()
+
+  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @callback connect(function_signature, event) :: :ok | {:error, any}
+
+  @doc """
+  Function to obtain resource information on a specific worker.
+  """
+  @spec connect(function_signature, event) :: :ok | {:error, any}
+  defdelegate connect(function, event), to: @adapter
+end

--- a/apps/core/lib/core/domain/ports/connectors/manager.ex
+++ b/apps/core/lib/core/domain/ports/connectors/manager.ex
@@ -16,22 +16,22 @@ defmodule Core.Domain.Ports.Connectors.Manager do
   @moduledoc """
   Port for managing Event Connectors.
   """
+  alias Data.ConnectedEvent
+
   @type function_signature :: %{
           name: String.t(),
           module: String.t()
         }
 
-  @type event :: map()
-
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback connect(function_signature, event) :: :ok | {:error, any}
+  @callback connect(function_signature, ConnectedEvent.t()) :: :ok | {:error, any}
   @callback disconnect(function_signature) :: :ok | {:error, any}
 
   @doc """
   Connects a function to a specific event. Should spawn a connector process.
   """
-  @spec connect(function_signature, event) :: :ok | {:error, any}
+  @spec connect(function_signature, ConnectedEvent.t()) :: :ok | {:error, any}
   defdelegate connect(function, event), to: @adapter
 
   @doc """

--- a/apps/core/lib/core/domain/ports/connectors/manager.ex
+++ b/apps/core/lib/core/domain/ports/connectors/manager.ex
@@ -26,10 +26,17 @@ defmodule Core.Domain.Ports.Connectors.Manager do
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback connect(function_signature, event) :: :ok | {:error, any}
+  @callback disconnect(function_signature) :: :ok | {:error, any}
 
   @doc """
-  Function to obtain resource information on a specific worker.
+  Connects a function to a specific event. Should spawn a connector process.
   """
   @spec connect(function_signature, event) :: :ok | {:error, any}
   defdelegate connect(function, event), to: @adapter
+
+  @doc """
+  Disconnects a function from all events. Should kill all related connector processes.
+  """
+  @spec disconnect(function_signature) :: :ok | {:error, any}
+  defdelegate disconnect(function), to: @adapter
 end

--- a/apps/core/test/core/integration/connectors/manager_test.exs
+++ b/apps/core/test/core/integration/connectors/manager_test.exs
@@ -1,0 +1,88 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Integration.Connectors.ManagerTest do
+  use ExUnit.Case
+
+  @moduletag integration_test: true
+
+  alias Core.Adapters.Connectors.Manager
+  alias Core.Adapters.Connectors.ManagerStore
+  alias Data.ConnectedEvent
+
+  describe "manager" do
+    test "connect/2 should return :ok when a function is connected to an event" do
+      event = %ConnectedEvent{type: "mqtt", params: %{host: "localhost", port: "9999"}}
+      func = %{name: "hello", module: "_"}
+      result = Manager.connect(func, event)
+      assert :ok = result
+    end
+
+    test "connect/2 should correctly store the pid when a function is connected to an event" do
+      event = %ConnectedEvent{type: "mqtt", params: %{host: "localhost", port: "9998"}}
+      func = %{name: "hello", module: "_"}
+      Manager.connect(func, event)
+      result = ManagerStore.get(func.name, func.module)
+      assert [pid1, pid2] = result
+      assert is_pid(pid1)
+      assert is_pid(pid2)
+    end
+
+    test "disconnect/1 should return :ok and remove the associated pids from the store when a function is disconnected from all events" do
+      func = %{name: "hello", module: "_"}
+      r1 = Manager.disconnect(func)
+      r2 = ManagerStore.get(func.name, func.module)
+      assert :ok == r1
+      assert :not_found = r2
+    end
+
+    test "disconnect/1 should return {:error, :not_found} when trying to disconnect a function with no associated events" do
+      func = %{name: "hello", module: "_"}
+      result = Manager.disconnect(func)
+      assert {:error, :not_found} == result
+    end
+  end
+
+  describe "processes" do
+    test "connect/2 should correctly spawn a process when a function is connected to an event" do
+      e1 = %ConnectedEvent{type: "mqtt", params: %{host: "localhost", port: "9999"}}
+      e2 = %ConnectedEvent{type: "mqtt", params: %{host: "localhost", port: "9998"}}
+      e3 = %ConnectedEvent{type: "mqtt", params: %{host: "localhost", port: "9997"}}
+      func = %{name: "hello", module: "_"}
+      Manager.connect(func, e1)
+      Manager.connect(func, e2)
+      Manager.connect(func, e3)
+      [p1, p2, p3] = ManagerStore.get(func.name, func.module)
+
+      assert is_pid(p1)
+      assert is_pid(p2)
+      assert is_pid(p3)
+
+      assert Process.alive?(p1)
+      assert Process.alive?(p2)
+      assert Process.alive?(p3)
+    end
+
+    test "disconnect/1 should correctly terminate the associated processes when called" do
+      func = %{name: "hello", module: "_"}
+      [p1, p2, p3] = ManagerStore.get(func.name, func.module)
+
+      Manager.disconnect(func)
+
+      assert !Process.alive?(p1)
+      assert !Process.alive?(p2)
+      assert !Process.alive?(p3)
+    end
+  end
+end

--- a/apps/data/lib/event.ex
+++ b/apps/data/lib/event.ex
@@ -1,0 +1,29 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Data.ConnectedEvent do
+  @moduledoc """
+    ConnectedEvent struct representing an event connected to a function through an Event Connector.
+
+    ## Fields
+      - type: the type of the event; defines the type of connector that will be spawned
+      - params: parameters passed to the connector
+  """
+  @type t :: %__MODULE__{
+          type: String.t(),
+          params: Map.t()
+        }
+  @enforce_keys [:type, :params]
+  defstruct [:type, :params]
+end

--- a/apps/data/lib/event.ex
+++ b/apps/data/lib/event.ex
@@ -22,7 +22,7 @@ defmodule Data.ConnectedEvent do
   """
   @type t :: %__MODULE__{
           type: String.t(),
-          params: Map.t()
+          params: map()
         }
   @enforce_keys [:type, :params]
   defstruct [:type, :params]

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,7 @@ config :core, Core.Domain.Ports.Commands, adapter: Core.Adapters.Commands.Worker
 config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
 config :core, Core.Domain.Ports.FunctionStore, adapter: Core.Adapters.FunctionStore.Mnesia
 config :core, Core.Domain.Ports.Telemetry.Metrics, adapter: Core.Adapters.Telemetry.Metrics
+config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Connectors.Manager
 
 config :core,
   ecto_repos: [Core.Repo]

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,6 +22,7 @@ config :core, Core.Domain.Ports.Commands, adapter: Core.Commands.Mock
 config :core, Core.Domain.Ports.Cluster, adapter: Core.Cluster.Mock
 config :core, Core.Domain.Ports.FunctionStore, adapter: Core.FunctionStore.Mock
 config :core, Core.Domain.Ports.Telemetry.Metrics, adapter: Core.Telemetry.Metrics.Mock
+config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Connectors.Manager.Mock
 
 # Configure your database
 


### PR DESCRIPTION
This PR adds the basic structures to handle Event Connectors.
Specifically:
- a `Connectors.Manager` port and adapter to handle the creation of new connector processes
- a `Connectors.Supervisor` dynamic supervisor to handle connector processes restarts

Event Connector processes are, for now, simple GenServers with no additional behaviour specification.
This closes #132.