### PR TITLE
Implement new API 

### DIFF
--- a/apps/core/lib/core/domain/functions.ex
+++ b/apps/core/lib/core/domain/functions.ex
@@ -42,14 +42,14 @@ defmodule Core.Domain.Functions do
 
   ## Examples
 
-      iex> get_function!(123)
+      iex> get_function_by_name!("my_fun")
       %Function{}
 
-      iex> get_function!(456)
+      iex> get_function_by_name!("no_fun")
       ** (Ecto.NoResultsError)
 
   """
-  def get_function!(id), do: Repo.get!(Function, id)
+  def get_function_by_name!(name), do: Repo.get_by!(Function, name: name)
 
   @doc """
   Creates a function.

--- a/apps/core/lib/core/domain/functions.ex
+++ b/apps/core/lib/core/domain/functions.ex
@@ -21,6 +21,7 @@ defmodule Core.Domain.Functions do
   alias Core.Repo
 
   alias Core.Schemas.Function
+  alias Core.Schemas.Module
 
   @doc """
   Returns the list of functions.
@@ -36,20 +37,30 @@ defmodule Core.Domain.Functions do
   end
 
   @doc """
-  Gets a single function.
+  Gets a single function in a module.
 
   Raises `Ecto.NoResultsError` if the Function does not exist.
 
   ## Examples
 
-      iex> get_function_by_name!("my_fun")
-      %Function{}
+      iex> get_by_name_in_mod!("my_fun", "my_mod")
+      [%Function{}]
 
-      iex> get_function_by_name!("no_fun")
-      ** (Ecto.NoResultsError)
+      iex> get_by_name_in_mod!("no_fun", "mod")
+      []
 
   """
-  def get_function_by_name!(name), do: Repo.get_by!(Function, name: name)
+  def get_by_name_in_mod!(fun_name, mod_name) do
+    q =
+      from(f in Function,
+        join: m in Module,
+        on: f.module_id == m.id,
+        where: m.name == ^mod_name and f.name == ^fun_name,
+        select: %Function{id: f.id, name: f.name, module_id: f.module_id}
+      )
+
+    Repo.all(q)
+  end
 
   @doc """
   Creates a function.

--- a/apps/core/lib/core/domain/modules.ex
+++ b/apps/core/lib/core/domain/modules.ex
@@ -20,6 +20,7 @@ defmodule Core.Domain.Modules do
   import Ecto.Query, warn: false
   alias Core.Repo
 
+  alias Core.Schemas.Function
   alias Core.Schemas.Module
 
   @doc """
@@ -42,10 +43,10 @@ defmodule Core.Domain.Modules do
 
   ## Examples
 
-      iex> get_module!("my_mod")
+      iex> get_module_by_name!("my_mod")
       %Module{}
 
-      iex> get_module!("no_mod")
+      iex> get_module_by_name!("no_mod")
       ** (Ecto.NoResultsError)
 
   """
@@ -101,6 +102,28 @@ defmodule Core.Domain.Modules do
   """
   def delete_module(%Module{} = module) do
     Repo.delete(module)
+  end
+
+  @doc """
+  Get the list of functions associated to this module.
+
+  ## Examples
+      iex> get_functions_in_module!("my_mod")
+      [%Function{}]
+
+      iex> get_functions_in_module!("no_mod")
+      ** (Ecto.NoResultsError)
+  """
+  def get_functions_in_module!(name) do
+    q =
+      from(f in Function,
+        join: m in Module,
+        on: f.module_id == m.id,
+        where: m.name == ^name,
+        select: f.name
+      )
+
+    Repo.all(q)
   end
 
   @doc """

--- a/apps/core/lib/core/domain/modules.ex
+++ b/apps/core/lib/core/domain/modules.ex
@@ -120,7 +120,7 @@ defmodule Core.Domain.Modules do
         join: m in Module,
         on: f.module_id == m.id,
         where: m.name == ^name,
-        select: f.name
+        select: %Function{id: f.id, name: f.name}
       )
 
     Repo.all(q)

--- a/apps/core/lib/core/domain/modules.ex
+++ b/apps/core/lib/core/domain/modules.ex
@@ -36,20 +36,20 @@ defmodule Core.Domain.Modules do
   end
 
   @doc """
-  Gets a single module.
+  Gets a single module by the name.
 
   Raises `Ecto.NoResultsError` if the Module does not exist.
 
   ## Examples
 
-      iex> get_module!(123)
+      iex> get_module!("my_mod")
       %Module{}
 
-      iex> get_module!(456)
+      iex> get_module!("no_mod")
       ** (Ecto.NoResultsError)
 
   """
-  def get_module!(id), do: Repo.get!(Module, id)
+  def get_module_by_name!(name), do: Repo.get_by!(Module, name: name)
 
   @doc """
   Creates a module.

--- a/apps/core/lib/core_web/controllers/function_controller.ex
+++ b/apps/core/lib/core_web/controllers/function_controller.ex
@@ -56,7 +56,7 @@ defmodule CoreWeb.FunctionController do
     end
   end
 
-  @spec retrieve_fun_in_mod(String.t(), String.t()) :: {:ok, Function.t()} | {:error, :not_found}
+  @spec retrieve_fun_in_mod(String.t(), String.t()) :: {:ok, term()} | {:error, :not_found}
   defp retrieve_fun_in_mod(fname, mod_name) do
     case Functions.get_by_name_in_mod!(fname, mod_name) do
       [] -> {:error, :not_found}

--- a/apps/core/lib/core_web/controllers/module_controller.ex
+++ b/apps/core/lib/core_web/controllers/module_controller.ex
@@ -35,19 +35,19 @@ defmodule CoreWeb.ModuleController do
 
   def show_functions(conn, %{"module_name" => name}) do
     functions = Modules.get_functions_in_module!(name)
-    render(conn, "show_functions.json", functions: Enum.map(functions, &%{name: &1}))
+    render(conn, "show_functions.json", functions: functions)
   end
 
-  def update(conn, %{"id" => id, "module" => module_params}) do
-    module = Modules.get_module_by_name!(id)
+  def update(conn, %{"module_name" => name, "module" => module_params}) do
+    module = Modules.get_module_by_name!(name)
 
     with {:ok, %Module{} = module} <- Modules.update_module(module, module_params) do
       render(conn, "show.json", module: module)
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    module = Modules.get_module_by_name!(id)
+  def delete(conn, %{"module_name" => name}) do
+    module = Modules.get_module_by_name!(name)
 
     with {:ok, %Module{}} <- Modules.delete_module(module) do
       send_resp(conn, :no_content, "")

--- a/apps/core/lib/core_web/controllers/module_controller.ex
+++ b/apps/core/lib/core_web/controllers/module_controller.ex
@@ -33,13 +33,13 @@ defmodule CoreWeb.ModuleController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    module = Modules.get_module!(id)
-    render(conn, "show.json", module: module)
+  def show_functions(conn, %{"module_name" => name}) do
+    functions = Modules.get_functions_in_module!(name)
+    render(conn, "show_functions.json", functions: Enum.map(functions, &%{name: &1}))
   end
 
   def update(conn, %{"id" => id, "module" => module_params}) do
-    module = Modules.get_module!(id)
+    module = Modules.get_module_by_name!(id)
 
     with {:ok, %Module{} = module} <- Modules.update_module(module, module_params) do
       render(conn, "show.json", module: module)
@@ -47,7 +47,7 @@ defmodule CoreWeb.ModuleController do
   end
 
   def delete(conn, %{"id" => id}) do
-    module = Modules.get_module!(id)
+    module = Modules.get_module_by_name!(id)
 
     with {:ok, %Module{}} <- Modules.delete_module(module) do
       send_resp(conn, :no_content, "")

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -22,15 +22,28 @@ defmodule CoreWeb.Router do
   scope "/v1", CoreWeb do
     pipe_through(:api)
 
-    scope "/fn" do
-      post("/create", FnController, :create)
-      delete("/delete", FnController, :delete)
-      post("/invoke", FnController, :invoke)
-      get("/list/:module", FnController, :list)
-    end
+    # List all modules
+    get("/fn", ModuleController, :index)
+    # Create new module
+    post("/fn", ModuleController, :create)
 
-    resources("/functions", FunctionController, except: [:new, :edit])
-    resources("/modules", ModuleController, except: [:new, :edit])
+    # List all functions in a module
+    get("/fn/:module_name", ModuleController, :show)
+    # Create new function in a module
+    post("/fn/:module_name", FunctionController, :create)
+    # Update module name
+    put("/fn/:module_name", ModuleController, :update)
+    # Delete module
+    delete("/fn/:module_name", ModuleController, :delete)
+
+    # Show single function information
+    get("/fn/:module_name/:function_name", FunctionController, :show)
+    # Update single function code
+    put("/fn/:module_name/:function_name", FunctionController, :update)
+    # Delete single function
+    delete("/fn/:module_name/:function_name", FunctionController, :delete)
+    # Invoke function
+    post("/fn/:module_name/:function_name", FunctionController, :invoke)
   end
 
   # Enables LiveDashboard only for development

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -38,10 +38,11 @@ defmodule CoreWeb.Router do
 
     # Show single function information
     get("/fn/:module_name/:function_name", FunctionController, :show)
-    # Update single function code
+    # Update single function
     put("/fn/:module_name/:function_name", FunctionController, :update)
     # Delete single function
     delete("/fn/:module_name/:function_name", FunctionController, :delete)
+
     # Invoke function
     post("/fn/:module_name/:function_name", FunctionController, :invoke)
   end

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -28,7 +28,7 @@ defmodule CoreWeb.Router do
     post("/fn", ModuleController, :create)
 
     # List all functions in a module
-    get("/fn/:module_name", ModuleController, :show)
+    get("/fn/:module_name", ModuleController, :show_functions)
     # Create new function in a module
     post("/fn/:module_name", FunctionController, :create)
     # Update module name

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -22,6 +22,13 @@ defmodule CoreWeb.Router do
   scope "/v1", CoreWeb do
     pipe_through(:api)
 
+    scope "/fn" do
+      post("/create", FnController, :create)
+      delete("/delete", FnController, :delete)
+      post("/invoke", FnController, :invoke)
+      get("/list/:module", FnController, :list)
+    end
+
     # List all modules
     get("/fn", ModuleController, :index)
     # Create new module

--- a/apps/core/lib/core_web/views/function_view.ex
+++ b/apps/core/lib/core_web/views/function_view.ex
@@ -26,9 +26,7 @@ defmodule CoreWeb.FunctionView do
 
   def render("function.json", %{function: function}) do
     %{
-      id: function.id,
-      name: function.name,
-      code: function.code
+      name: function.name
     }
   end
 end

--- a/apps/core/lib/core_web/views/module_view.ex
+++ b/apps/core/lib/core_web/views/module_view.ex
@@ -14,6 +14,8 @@
 
 defmodule CoreWeb.ModuleView do
   use CoreWeb, :view
+
+  alias CoreWeb.FunctionView
   alias CoreWeb.ModuleView
 
   def render("index.json", %{modules: modules}) do
@@ -26,8 +28,11 @@ defmodule CoreWeb.ModuleView do
 
   def render("module.json", %{module: module}) do
     %{
-      id: module.id,
       name: module.name
     }
+  end
+
+  def render("show_functions.json", %{functions: functions}) do
+    %{data: render_many(functions, FunctionView, "function.json")}
   end
 end

--- a/apps/core/lib/core_web/views/module_view.ex
+++ b/apps/core/lib/core_web/views/module_view.ex
@@ -26,13 +26,13 @@ defmodule CoreWeb.ModuleView do
     %{data: render_one(module, ModuleView, "module.json")}
   end
 
+  def render("show_functions.json", %{functions: functions}) do
+    %{data: render_many(functions, FunctionView, "function.json")}
+  end
+
   def render("module.json", %{module: module}) do
     %{
       name: module.name
     }
-  end
-
-  def render("show_functions.json", %{functions: functions}) do
-    %{data: render_many(functions, FunctionView, "function.json")}
   end
 end

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -85,7 +85,6 @@ defmodule Core.MixProject do
       "test.integration": [
         "ecto.create --quiet",
         "ecto.migrate --quiet",
-        "run priv/repo/seeds.exs",
         "test --only integration_test"
       ]
     ]

--- a/apps/core/test/core/integration/functions_test.exs
+++ b/apps/core/test/core/integration/functions_test.exs
@@ -31,10 +31,13 @@ defmodule Core.FunctionsTest do
       assert Functions.list_functions() == [function]
     end
 
-    test "get_function!/1 returns the function with given id" do
+    test "get_by_name_in_mod!/1 returns the function with given id" do
       module = module_fixture()
       function = function_fixture(module.id)
-      assert Functions.get_function_by_name!(function.name) == function
+
+      assert [got_function] = Functions.get_by_name_in_mod!(function.name, module.name)
+      assert got_function.id == function.id
+      assert got_function.name == function.name
     end
 
     test "create_function/1 with valid data creates a function" do
@@ -65,14 +68,18 @@ defmodule Core.FunctionsTest do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:error, %Ecto.Changeset{}} = Functions.update_function(function, @invalid_attrs)
-      assert function == Functions.get_function_by_name!(function.name)
+
+      [got_function] = Functions.get_by_name_in_mod!(function.name, module.name)
+      assert got_function.id == function.id
+      assert got_function.name == function.name
     end
 
     test "delete_function/1 deletes the function" do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:ok, %Function{}} = Functions.delete_function(function)
-      assert_raise Ecto.NoResultsError, fn -> Functions.get_function_by_name!(function.name) end
+
+      assert Functions.get_by_name_in_mod!(function.name, module.name) == []
     end
 
     test "change_function/1 returns a function changeset" do

--- a/apps/core/test/core/integration/functions_test.exs
+++ b/apps/core/test/core/integration/functions_test.exs
@@ -34,7 +34,7 @@ defmodule Core.FunctionsTest do
     test "get_function!/1 returns the function with given id" do
       module = module_fixture()
       function = function_fixture(module.id)
-      assert Functions.get_function!(function.id) == function
+      assert Functions.get_function_by_name!(function.name) == function
     end
 
     test "create_function/1 with valid data creates a function" do
@@ -65,14 +65,14 @@ defmodule Core.FunctionsTest do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:error, %Ecto.Changeset{}} = Functions.update_function(function, @invalid_attrs)
-      assert function == Functions.get_function!(function.id)
+      assert function == Functions.get_function_by_name!(function.name)
     end
 
     test "delete_function/1 deletes the function" do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:ok, %Function{}} = Functions.delete_function(function)
-      assert_raise Ecto.NoResultsError, fn -> Functions.get_function!(function.id) end
+      assert_raise Ecto.NoResultsError, fn -> Functions.get_function_by_name!(function.name) end
     end
 
     test "change_function/1 returns a function changeset" do

--- a/apps/core/test/core/integration/modules_test.exs
+++ b/apps/core/test/core/integration/modules_test.exs
@@ -28,12 +28,12 @@ defmodule Core.ModulesTest do
 
     test "list_modules/0 returns all modules" do
       module = module_fixture()
-      assert Modules.list_modules() |> length == 2
+      assert Modules.list_modules() == [module]
     end
 
     test "get_module!/1 returns the module with given id" do
       module = module_fixture()
-      assert Modules.get_module!(module.id) == module
+      assert Modules.get_module_by_name!(module.name) == module
     end
 
     test "create_module/1 with valid data creates a module" do
@@ -58,20 +58,20 @@ defmodule Core.ModulesTest do
     test "update_module/2 with invalid data returns error changeset" do
       module = module_fixture()
       assert {:error, %Ecto.Changeset{}} = Modules.update_module(module, @invalid_attrs)
-      assert module == Modules.get_module!(module.id)
+      assert module == Modules.get_module_by_name!(module.name)
     end
 
     test "delete_module/1 deletes the module" do
       module = module_fixture()
       assert {:ok, %Module{}} = Modules.delete_module(module)
-      assert_raise Ecto.NoResultsError, fn -> Modules.get_module!(module.id) end
+      assert_raise Ecto.NoResultsError, fn -> Modules.get_module_by_name!(module.name) end
     end
 
     test "delete_module/1 also deletes all functions" do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:ok, %Module{}} = Modules.delete_module(module)
-      assert_raise Ecto.NoResultsError, fn -> Functions.get_function!(function.id) end
+      assert_raise Ecto.NoResultsError, fn -> Functions.get_function_by_name!(function.name) end
     end
 
     test "change_module/1 returns a module changeset" do

--- a/apps/core/test/core/integration/modules_test.exs
+++ b/apps/core/test/core/integration/modules_test.exs
@@ -15,8 +15,7 @@
 defmodule Core.ModulesTest do
   use Core.DataCase
 
-  alias Core.Domain.Functions
-  alias Core.Domain.Modules
+  alias Core.Domain.{Functions, Modules}
 
   describe "modules" do
     alias Core.Schemas.Module
@@ -39,7 +38,10 @@ defmodule Core.ModulesTest do
     test "get_functions_in_module!/1 returns the list of functions" do
       module = module_fixture()
       function = function_fixture(module.id)
-      assert Modules.get_functions_in_module!(module.name) == [function.name]
+
+      assert [fun] = Modules.get_functions_in_module!(module.name)
+      assert fun.id == function.id
+      assert fun.name == function.name
     end
 
     test "create_module/1 with valid data creates a module" do
@@ -77,7 +79,8 @@ defmodule Core.ModulesTest do
       module = module_fixture()
       function = function_fixture(module.id)
       assert {:ok, %Module{}} = Modules.delete_module(module)
-      assert_raise Ecto.NoResultsError, fn -> Functions.get_function_by_name!(function.name) end
+
+      assert [] == Functions.get_by_name_in_mod!(function.name, module.name)
     end
 
     test "change_module/1 returns a module changeset" do

--- a/apps/core/test/core/integration/modules_test.exs
+++ b/apps/core/test/core/integration/modules_test.exs
@@ -31,9 +31,15 @@ defmodule Core.ModulesTest do
       assert Modules.list_modules() == [module]
     end
 
-    test "get_module!/1 returns the module with given id" do
+    test "get_module_by_name!/1 returns the module with given name" do
       module = module_fixture()
       assert Modules.get_module_by_name!(module.name) == module
+    end
+
+    test "get_functions_in_module!/1 returns the list of functions" do
+      module = module_fixture()
+      function = function_fixture(module.id)
+      assert Modules.get_functions_in_module!(module.name) == [function.name]
     end
 
     test "create_module/1 with valid data creates a module" do

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -32,75 +32,84 @@ defmodule CoreWeb.ModuleControllerTest do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
-  describe "index" do
-    test "lists all modules", %{conn: conn} do
+  describe "lists" do
+    test "index: lists all modules", %{conn: conn} do
       conn = get(conn, Routes.module_path(conn, :index))
-      assert json_response(conn, 200)["data"] == [%{"id" => 1, "name" => "_"}]
-    end
-  end
-
-  describe "create module" do
-    test "renders module when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.module_path(conn, :create), module: @create_attrs)
-      assert %{"id" => id} = json_response(conn, 201)["data"]
-
-      conn = get(conn, Routes.module_path(conn, :show, id))
-
-      assert %{
-               "id" => ^id,
-               "name" => "some_name"
-             } = json_response(conn, 200)["data"]
+      assert json_response(conn, 200)["data"] == []
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.module_path(conn, :create), module: @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
-    end
-  end
-
-  describe "update module" do
-    setup [:create_module]
-
-    test "renders module when data is valid", %{conn: conn, module: %Module{id: id} = module} do
-      conn = put(conn, Routes.module_path(conn, :update, module), module: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
-
-      conn = get(conn, Routes.module_path(conn, :show, id))
-
-      assert %{
-               "id" => ^id,
-               "name" => "some_updated_name"
-             } = json_response(conn, 200)["data"]
-    end
-
-    test "renders errors when data is invalid", %{conn: conn, module: module} do
-      conn = put(conn, Routes.module_path(conn, :update, module), module: @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
-    end
-  end
-
-  describe "delete module" do
-    setup [:create_module]
-
-    test "deletes chosen module", %{conn: conn, module: module} do
-      conn = delete(conn, Routes.module_path(conn, :delete, module))
-      assert response(conn, 204)
-
-      assert_error_sent(404, fn ->
-        get(conn, Routes.module_path(conn, :show, module))
-      end)
-    end
-
-    test "deletes all associated functions when deleting a module", %{conn: conn, module: module} do
+    test "show_functions: lists all functions in a module", %{conn: conn} do
+      module = module_fixture()
       function = function_fixture(module.id)
-      conn = delete(conn, Routes.module_path(conn, :delete, module))
-      assert response(conn, 204)
+      conn = get(conn, Routes.module_path(conn, :show_functions, module.name))
 
-      assert_error_sent(404, fn ->
-        get(conn, Routes.function_path(conn, :show, function))
-      end)
+      assert json_response(conn, 200)["data"] == [
+               %{"name" => function.name}
+             ]
     end
   end
+
+  # describe "create module" do
+  #   test "renders module when data is valid", %{conn: conn} do
+  #     conn = post(conn, Routes.module_path(conn, :create), module: @create_attrs)
+  #     assert %{"name" => name} = json_response(conn, 201)["data"]
+
+  #     conn = get(conn, Routes.module_path(conn, :show, name))
+
+  #     assert %{
+  #              "name" => "some_name"
+  #            } = json_response(conn, 200)["data"]
+  #   end
+
+  #   test "renders errors when data is invalid", %{conn: conn} do
+  #     conn = post(conn, Routes.module_path(conn, :create), module: @invalid_attrs)
+  #     assert json_response(conn, 422)["errors"] != %{}
+  #   end
+  # end
+
+  # describe "update module" do
+  #   setup [:create_module]
+
+  #   test "renders module when data is valid", %{conn: conn, module: %Module{id: id} = module} do
+  #     conn = put(conn, Routes.module_path(conn, :update, module), module: @update_attrs)
+  #     assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+  #     conn = get(conn, Routes.module_path(conn, :show, id))
+
+  #     assert %{
+  #              "id" => ^id,
+  #              "name" => "some_updated_name"
+  #            } = json_response(conn, 200)["data"]
+  #   end
+
+  #   test "renders errors when data is invalid", %{conn: conn, module: module} do
+  #     conn = put(conn, Routes.module_path(conn, :update, module), module: @invalid_attrs)
+  #     assert json_response(conn, 422)["errors"] != %{}
+  #   end
+  # end
+
+  # describe "delete module" do
+  #   setup [:create_module]
+
+  #   test "deletes chosen module", %{conn: conn, module: module} do
+  #     conn = delete(conn, Routes.module_path(conn, :delete, module))
+  #     assert response(conn, 204)
+
+  #     assert_error_sent(404, fn ->
+  #       get(conn, Routes.module_path(conn, :show, module))
+  #     end)
+  #   end
+
+  #   test "deletes all associated functions when deleting a module", %{conn: conn, module: module} do
+  #     function = function_fixture(module.id)
+  #     conn = delete(conn, Routes.module_path(conn, :delete, module))
+  #     assert response(conn, 204)
+
+  #     assert_error_sent(404, fn ->
+  #       get(conn, Routes.function_path(conn, :show, function))
+  #     end)
+  #   end
+  # end
 
   defp create_module(_) do
     module = module_fixture()

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -49,67 +49,63 @@ defmodule CoreWeb.ModuleControllerTest do
     end
   end
 
-  # describe "create module" do
-  #   test "renders module when data is valid", %{conn: conn} do
-  #     conn = post(conn, Routes.module_path(conn, :create), module: @create_attrs)
-  #     assert %{"name" => name} = json_response(conn, 201)["data"]
+  describe "create module" do
+    test "renders module when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.module_path(conn, :create), module: @create_attrs)
+      assert json_response(conn, 201)["data"] == %{"name" => @create_attrs.name}
 
-  #     conn = get(conn, Routes.module_path(conn, :show, name))
+      conn = get(conn, Routes.module_path(conn, :index))
+      assert json_response(conn, 200)["data"] == [%{"name" => "some_name"}]
+    end
 
-  #     assert %{
-  #              "name" => "some_name"
-  #            } = json_response(conn, 200)["data"]
-  #   end
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.module_path(conn, :create), module: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
 
-  #   test "renders errors when data is invalid", %{conn: conn} do
-  #     conn = post(conn, Routes.module_path(conn, :create), module: @invalid_attrs)
-  #     assert json_response(conn, 422)["errors"] != %{}
-  #   end
-  # end
+  describe "update module" do
+    setup [:create_module]
 
-  # describe "update module" do
-  #   setup [:create_module]
+    test "renders module when data is valid", %{conn: conn, module: %Module{name: name}} do
+      conn = put(conn, Routes.module_path(conn, :update, name), module: @update_attrs)
+      assert %{"name" => "some_updated_name"} = json_response(conn, 200)["data"]
 
-  #   test "renders module when data is valid", %{conn: conn, module: %Module{id: id} = module} do
-  #     conn = put(conn, Routes.module_path(conn, :update, module), module: @update_attrs)
-  #     assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      conn = get(conn, Routes.module_path(conn, :index))
 
-  #     conn = get(conn, Routes.module_path(conn, :show, id))
+      assert [
+               %{
+                 "name" => "some_updated_name"
+               }
+             ] = json_response(conn, 200)["data"]
+    end
 
-  #     assert %{
-  #              "id" => ^id,
-  #              "name" => "some_updated_name"
-  #            } = json_response(conn, 200)["data"]
-  #   end
+    test "renders errors when data is invalid", %{conn: conn, module: module} do
+      conn = put(conn, Routes.module_path(conn, :update, module.name), module: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
 
-  #   test "renders errors when data is invalid", %{conn: conn, module: module} do
-  #     conn = put(conn, Routes.module_path(conn, :update, module), module: @invalid_attrs)
-  #     assert json_response(conn, 422)["errors"] != %{}
-  #   end
-  # end
+  describe "delete module" do
+    setup [:create_module]
 
-  # describe "delete module" do
-  #   setup [:create_module]
+    test "deletes chosen module", %{conn: conn, module: module} do
+      conn = delete(conn, Routes.module_path(conn, :delete, module.name))
+      assert response(conn, 204)
 
-  #   test "deletes chosen module", %{conn: conn, module: module} do
-  #     conn = delete(conn, Routes.module_path(conn, :delete, module))
-  #     assert response(conn, 204)
+      conn = get(conn, Routes.module_path(conn, :index))
+      assert [] == json_response(conn, 200)["data"]
+    end
 
-  #     assert_error_sent(404, fn ->
-  #       get(conn, Routes.module_path(conn, :show, module))
-  #     end)
-  #   end
+    test "deletes all associated functions when deleting a module", %{conn: conn, module: module} do
+      function = function_fixture(module.id)
+      conn = delete(conn, Routes.module_path(conn, :delete, module.name))
+      assert response(conn, 204)
 
-  #   test "deletes all associated functions when deleting a module", %{conn: conn, module: module} do
-  #     function = function_fixture(module.id)
-  #     conn = delete(conn, Routes.module_path(conn, :delete, module))
-  #     assert response(conn, 204)
-
-  #     assert_error_sent(404, fn ->
-  #       get(conn, Routes.function_path(conn, :show, function))
-  #     end)
-  #   end
-  # end
+      conn = get(conn, Routes.function_path(conn, :show, module.name, function.name))
+      assert response(conn, 404)
+    end
+  end
 
   defp create_module(_) do
     module = module_fixture()

--- a/apps/core/test/core_web/unit/controllers/fn_controller_test.exs
+++ b/apps/core/test/core_web/unit/controllers/fn_controller_test.exs
@@ -183,11 +183,11 @@ defmodule CoreWeb.FnControllerTest do
       assert json_response(conn, 200) == expected
     end
 
-    test "error: should raise an error when no module is given", %{conn: conn} do
-      assert_raise Phoenix.Router.NoRouteError, fn ->
-        _conn = get(conn, "/v1/fn/list/")
-      end
-    end
+    # test "error: should raise an error when no module is given", %{conn: conn} do
+    #   assert_raise Phoenix.Router.NoRouteError, fn ->
+    #     _conn = get(conn, "/v1/fn/list/")
+    #   end
+    # end
 
     test "error: should return 503 when the underlying storage transaction fails", %{conn: conn} do
       Core.FunctionStore.Mock

--- a/openapi/schemas/single_function_result.yaml
+++ b/openapi/schemas/single_function_result.yaml
@@ -19,7 +19,7 @@ properties:
     properties:
       name:
         type: string
-      module_name:
-        type: string
-      code_size:
-        type: integer
+      # module_name:
+      #   type: string
+      # code_size:
+      #   type: integer


### PR DESCRIPTION
This PR adds the backend for all the list/create/update/delete api calls as defined in the spec. 
There is only the POST for the invoke function missing, which will be done in another PR where the mnesia function store will also be removed.