### PR TITLE
Add `events` parameter in function creation/update

### DIFF
--- a/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
+++ b/apps/core/lib/core/adapters/connectors/event_connectors/mqtt.ex
@@ -25,31 +25,15 @@ defmodule Core.Adapters.Connectors.EventConnectors.Mqtt do
     GenServer.start_link(__MODULE__, params)
   end
 
-  @spec init(%{
-          :function => String.t(),
-          :module => String.t(),
-          :params => %{
-            :host => atom(),
-            :port => integer(),
-            :topic => String.t()
-          }
-        }) ::
-          {:ok,
-           %{
-             :function => String.t(),
-             :host => atom(),
-             :module => String.t(),
-             :pid => pid(),
-             :port => integer(),
-             :topic => String.t()
-           }}
-          | {:stop, :normal}
   def init(%{
         function: function,
         module: module,
-        params: %{host: _host, port: _port, topic: _topic} = params
+        params: %{"host" => host, "port" => port, "topic" => topic}
       }) do
     Process.flag(:trap_exit, true)
+
+    # params come from json, but emqtt only accepts atoms as host and integers as port
+    params = %{host: String.to_atom(host), port: String.to_integer(port), topic: topic}
 
     case connect_to_broker(params) do
       {:ok, pid} ->

--- a/apps/core/lib/core/domain/events.ex
+++ b/apps/core/lib/core/domain/events.ex
@@ -37,7 +37,11 @@ defmodule Core.Domain.Events do
     []
   end
 
-  def connect_events(function, module, [_] = events) do
+  def connect_events(_, _, []) do
+    []
+  end
+
+  def connect_events(function, module, [_ | _] = events) do
     Enum.map(events, fn e -> connect_single_event(function, module, e) end)
   end
 
@@ -83,7 +87,11 @@ defmodule Core.Domain.Events do
     []
   end
 
-  def update_events(function, module, [_] = events) do
+  def update_events(_, _, []) do
+    []
+  end
+
+  def update_events(function, module, [_ | _] = events) do
     Manager.disconnect(%{name: function, module: module})
     connect_events(function, module, events)
   end

--- a/apps/core/lib/core/domain/events.ex
+++ b/apps/core/lib/core/domain/events.ex
@@ -1,0 +1,54 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Events do
+  @moduledoc """
+
+  """
+  alias Core.Domain.Ports.Connectors.Manager
+
+  @spec connect_events(String.t(), String.t(), [map()] | nil) :: [:ok | {:error, any}]
+  def connect_events(_, _, nil) do
+    []
+  end
+
+  def connect_events(function, module, [_] = events) do
+    Enum.map(events, fn e -> connect_single_event(function, module, e) end)
+  end
+
+  @spec connect_single_event(String.t(), String.t(), map) :: :ok | {:error, any}
+  def connect_single_event(function, module, %{"type" => type, "params" => params}) do
+    connected_event = %Data.ConnectedEvent{type: type, params: params}
+    Manager.connect(%{name: function, module: module}, connected_event)
+  end
+
+  def connect_single_event(_, _, _) do
+    {:error, :bad_event_format}
+  end
+
+  @spec update_events(String.t(), String.t(), [map()] | nil) :: [:ok | {:error, any}]
+  def update_events(_, _, nil) do
+    []
+  end
+
+  def update_events(function, module, [_] = events) do
+    Manager.disconnect(%{name: function, module: module})
+    connect_events(function, module, events)
+  end
+
+  @spec disconnect_events(String.t(), String.t()) :: :ok | {:error, any}
+  def disconnect_events(function, module) do
+    Manager.disconnect(%{name: function, module: module})
+  end
+end

--- a/apps/core/lib/core_web/controllers/function_controller.ex
+++ b/apps/core/lib/core_web/controllers/function_controller.ex
@@ -47,8 +47,6 @@ defmodule CoreWeb.FunctionController do
            %{"name" => fn_name, "code" => code}
            |> Map.put_new("module_id", module.id)
            |> Functions.create_function() do
-      # TODO: update API spec with new possible return code and object
-
       event_results = Events.connect_events(fn_name, module_name, Map.get(params, "events"))
 
       event_errors? =
@@ -88,8 +86,6 @@ defmodule CoreWeb.FunctionController do
           "name" => new_name
         } = params
       ) do
-    # TODO: update API spec with new possible return type and object
-
     with {:ok, code} <- File.read(tmp_path),
          {:ok, %Function{} = function} <- retrieve_fun_in_mod(name, mod_name),
          {:ok, %Function{} = function} <-

--- a/apps/core/lib/core_web/controllers/function_controller.ex
+++ b/apps/core/lib/core_web/controllers/function_controller.ex
@@ -60,7 +60,7 @@ defmodule CoreWeb.FunctionController do
       if event_errors? do
         conn
         |> put_status(:multi_status)
-        |> render("show.json", function: function, events: event_results)
+        |> render("show.json", data: %{function: function, events: event_results})
       else
         conn
         |> put_status(:created)
@@ -105,7 +105,7 @@ defmodule CoreWeb.FunctionController do
       if event_errors? do
         conn
         |> put_status(:multi_status)
-        |> render("show.json", function: function, events: event_results)
+        |> render("show.json", data: %{function: function, events: event_results})
       else
         conn
         |> render("show.json", function: function)

--- a/apps/core/lib/core_web/views/function_view.ex
+++ b/apps/core/lib/core_web/views/function_view.ex
@@ -20,13 +20,47 @@ defmodule CoreWeb.FunctionView do
     %{data: render_many(functions, FunctionView, "function.json")}
   end
 
+  def render("show.json", %{data: %{function: _function, events: _events} = content}) do
+    %{
+      data: render_one(content, FunctionView, "function_events.json", as: :data)
+    }
+  end
+
   def render("show.json", %{function: function}) do
     %{data: render_one(function, FunctionView, "function.json")}
+  end
+
+  def render("function_events.json", %{data: %{function: function, events: events}}) do
+    successful = events |> Enum.count(fn e -> e == :ok end)
+    failed = length(events) - successful
+
+    %{
+      name: function.name,
+      events: render_many(events, FunctionView, "event.json", as: :result),
+      metadata: %{
+        successful: successful,
+        failed: failed,
+        total: length(events)
+      }
+    }
   end
 
   def render("function.json", %{function: function}) do
     %{
       name: function.name
+    }
+  end
+
+  def render("event.json", %{result: :ok}) do
+    %{
+      status: "success"
+    }
+  end
+
+  def render("event.json", %{result: {:error, err}}) do
+    %{
+      status: "error",
+      message: "#{inspect(err)}"
     }
   end
 end

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -77,7 +77,7 @@ defmodule Core.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "test.integration": [
         "ecto.create --quiet",

--- a/apps/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -32,6 +32,7 @@ defmodule CoreWeb.FunctionControllerTest do
   setup %{conn: conn} do
     Core.Commands.Mock |> Mox.stub_with(Core.Adapters.Commands.Test)
     Core.Cluster.Mock |> Mox.stub_with(Core.Adapters.Cluster.Test)
+    Core.Connectors.Manager.Mock |> Mox.stub_with(Core.Adapters.Connectors.Test)
 
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -183,9 +183,9 @@ paths:
 
     # PUT /fn/{mod}/{fun}
     put:
-      summary: Update function code
+      summary: Update function
       operationId: update_function
-      description: Update function code
+      description: Update function
       tags:
         - functions
       parameters:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -120,6 +120,8 @@ paths:
       responses:
         "201":
           $ref: "responses/null_response.yaml"
+        "207":
+          $ref: "responses/mixed_response_events.yaml"
         default:
           $ref: "responses/unexpected_error.yaml"
 
@@ -214,6 +216,8 @@ paths:
       responses:
         "200":
           $ref: "responses/null_response.yaml"
+        "207":
+          $ref: "responses/mixed_response_events.yaml"
         default:
           $ref: "responses/unexpected_error.yaml"
 

--- a/openapi/responses/_index.yaml
+++ b/openapi/responses/_index.yaml
@@ -16,3 +16,5 @@ unexpected_error:
   $ref: "./unexpected_error.yaml"
 null_response:
   $ref: "./null_response.yaml"
+mixed_response_events:
+  $ref: "./mixed_response_events.yaml"

--- a/openapi/responses/mixed_response_events.yaml
+++ b/openapi/responses/mixed_response_events.yaml
@@ -12,33 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module_name:
-  $ref: "./module_name.yaml"
-
-single_module_result:
-  $ref: "./single_module_result.yaml"
-
-module_names_result:
-  $ref: "./module_names_result.yaml"
-
-single_function_result:
-  $ref: "./single_function_result.yaml"
-
-invoke_input:
-  $ref: "./invoke_input.yaml"
-
-invoke_result:
-  $ref: "./invoke_result.yaml"
-
-function_create_update:
-  $ref: "./function_create_update.yaml"
-
-connected_event:
-  $ref: "./connected_event.yaml"
-
-mixed_event_results:
-  $ref: "./mixed_event_results.yaml"
-
-error:
-  $ref: "./error.yaml"
-
+description: Mixed response
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/mixed_event_results.yaml"

--- a/openapi/schemas/_index.yaml
+++ b/openapi/schemas/_index.yaml
@@ -33,6 +33,9 @@ invoke_result:
 function_create_update:
   $ref: "./function_create_update.yaml"
 
+connected_event:
+  $ref: "./connected_event.yaml"
+
 error:
   $ref: "./error.yaml"
 

--- a/openapi/schemas/connected_event.yaml
+++ b/openapi/schemas/connected_event.yaml
@@ -14,15 +14,10 @@
 
 type: object
 properties:
-  name:
-    description: Name of the function
+  type:
     type: string
-  code:
-    type: string
-    format: binary
-    description: File with the code of the function
-  events:
-    type: array
-    description: Events that can trigger the function
-    items:
-      $ref: "./connected_event.yaml"
+    enum: [mqtt]
+    description: Type of the event
+  params:
+    type: object
+    description: Additional parameters of the event

--- a/openapi/schemas/mixed_event_results.yaml
+++ b/openapi/schemas/mixed_event_results.yaml
@@ -1,0 +1,47 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+properties:
+  data:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The name of the function
+      events:
+        description: The results of event connection, both successful and failed
+        type: array
+        items:
+          type: object
+          properties:
+            status:
+              type: string
+              enum: ["success", "error"]
+              description: Whether the corresponding event was connected successfully
+            message:
+              type: string
+              description: Additional information on the error
+      metadata:
+        type: object
+        properties:
+          successful:
+            type: integer
+            description: The amount of events that was successfully connected
+          failed:
+            type: integer
+            description: The amount of events that wasn't successfully connected
+          total:
+            type: integer
+            description: The total amount of events that was passed


### PR DESCRIPTION
This PR adds the `events` parameter in the request body of function creation and update.
Additionally:
- the HTTP 207 response code was added in both requests, used when some or all event connections failed
- event connection/disconnection is now linked to function creation/deletion, i.e., Event Connectors are spawned when a function is created, and killed when the function is deleted
- MQTT Event Connector now handles parameters with string keys (instead of atoms), allowing for easier integration with the json parameters passed from `core_web`
- the `Core.Domain.Events` module was added as a wrapper for the `Core.Domain.Ports.Connectors.Manager` port, for easier interaction from `core_web`

This closes #133.