### PR TITLE
Add module name in get module response

### DIFF
--- a/apps/core/lib/core_web/controllers/module_controller.ex
+++ b/apps/core/lib/core_web/controllers/module_controller.ex
@@ -35,7 +35,7 @@ defmodule CoreWeb.ModuleController do
 
   def show_functions(conn, %{"module_name" => name}) do
     functions = Modules.get_functions_in_module!(name)
-    render(conn, "show_functions.json", functions: functions)
+    render(conn, "show_functions.json", %{module_name: name, functions: functions})
   end
 
   def update(conn, %{"module_name" => name, "module" => module_params}) do

--- a/apps/core/lib/core_web/views/module_view.ex
+++ b/apps/core/lib/core_web/views/module_view.ex
@@ -26,8 +26,8 @@ defmodule CoreWeb.ModuleView do
     %{data: render_one(module, ModuleView, "module.json")}
   end
 
-  def render("show_functions.json", %{functions: functions}) do
-    %{data: render_many(functions, FunctionView, "function.json")}
+  def render("show_functions.json", %{module_name: name, functions: functions}) do
+    %{data: %{name: name, functions: render_many(functions, FunctionView, "function.json")}}
   end
 
   def render("module.json", %{module: module}) do

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -43,9 +43,8 @@ defmodule CoreWeb.ModuleControllerTest do
       function = function_fixture(module.id)
       conn = get(conn, Routes.module_path(conn, :show_functions, module.name))
 
-      assert json_response(conn, 200)["data"] == [
-               %{"name" => function.name}
-             ]
+      assert json_response(conn, 200)["data"] ==
+               %{"functions" => [%{"name" => "some_name"}], "name" => module.name}
     end
   end
 


### PR DESCRIPTION
This PR covers the last task of #154 

It adds the module name as part of the response for the get request to /v1/{module} that retrieves all functions in the module.