### PR TITLE
Fix delete return and module get_by_name usage

### DIFF
--- a/apps/core/lib/core/adapters/connectors/manager.ex
+++ b/apps/core/lib/core/adapters/connectors/manager.ex
@@ -98,12 +98,7 @@ defmodule Core.Adapters.Connectors.Manager do
   def disconnect(%{name: function, module: module}) do
     supervisor = "#{Atom.to_string(@main_supervisor)}.#{module}/#{function}"
 
-    case Registry.lookup(@registry, supervisor) do
-      [] ->
-        {:error, :not_found}
-
-      [{pid, _}] ->
-        DynamicSupervisor.terminate_child(@main_supervisor, pid)
-    end
+    Registry.lookup(@registry, supervisor)
+    |> Enum.each(fn {pid, _} -> DynamicSupervisor.terminate_child(@main_supervisor, pid) end)
   end
 end

--- a/apps/core/lib/core/adapters/data_sinks/manager.ex
+++ b/apps/core/lib/core/adapters/data_sinks/manager.ex
@@ -111,12 +111,7 @@ defmodule Core.Adapters.DataSinks.Manager do
   def unplug(%{name: function, module: module}) do
     supervisor = "#{Atom.to_string(@main_supervisor)}.#{module}/#{function}"
 
-    case Registry.lookup(@registry, supervisor) do
-      [] ->
-        {:error, :not_found}
-
-      [{pid, _}] ->
-        DynamicSupervisor.terminate_child(@main_supervisor, pid)
-    end
+    Registry.lookup(@registry, supervisor)
+    |> Enum.each(fn {pid, _} -> DynamicSupervisor.terminate_child(@main_supervisor, pid) end)
   end
 end

--- a/apps/core/lib/core/domain/modules.ex
+++ b/apps/core/lib/core/domain/modules.ex
@@ -39,18 +39,23 @@ defmodule Core.Domain.Modules do
   @doc """
   Gets a single module by the name.
 
-  Raises `Ecto.NoResultsError` if the Module does not exist.
+  Returns `{:ok, %Module{}}` if the module exists, `{error, :not_found}` otherwise.
 
   ## Examples
 
-      iex> get_module_by_name!("my_mod")
-      %Module{}
+      iex> get_module_by_name("my_mod")
+      {:ok, %Module{}}
 
-      iex> get_module_by_name!("no_mod")
-      ** (Ecto.NoResultsError)
+      iex> get_module_by_name("no_mod")
+      {:error, :not_found}
 
   """
-  def get_module_by_name!(name), do: Repo.get_by!(Module, name: name)
+  def get_module_by_name(name) do
+    case Repo.get_by(Module, name: name) do
+      nil -> {:error, :not_found}
+      mod -> {:ok, mod}
+    end
+  end
 
   @doc """
   Creates a module.

--- a/apps/core/lib/core_web/controllers/function_controller.ex
+++ b/apps/core/lib/core_web/controllers/function_controller.ex
@@ -17,7 +17,7 @@ defmodule CoreWeb.FunctionController do
 
   alias Core.Domain.DataSink
   alias Core.Domain.{Events, Functions, Invoker, Modules}
-  alias Core.Schemas.{Function, Module}
+  alias Core.Schemas.Function
   alias Data.InvokeParams
 
   require Logger
@@ -58,7 +58,7 @@ defmodule CoreWeb.FunctionController do
       {:error, :bad_params}
     else
       with {:ok, code} <- File.read(tmp_path),
-           %Module{} = module <- Modules.get_module_by_name!(module_name),
+           {:ok, module} <- Modules.get_module_by_name(module_name),
            {:ok, %Function{} = function} <-
              %{"name" => fn_name, "code" => code}
              |> Map.put_new("module_id", module.id)

--- a/apps/core/lib/core_web/controllers/module_controller.ex
+++ b/apps/core/lib/core_web/controllers/module_controller.ex
@@ -39,17 +39,15 @@ defmodule CoreWeb.ModuleController do
   end
 
   def update(conn, %{"module_name" => name, "module" => module_params}) do
-    module = Modules.get_module_by_name!(name)
-
-    with {:ok, %Module{} = module} <- Modules.update_module(module, module_params) do
+    with {:ok, module} <- Modules.get_module_by_name(name),
+         {:ok, %Module{} = module} <- Modules.update_module(module, module_params) do
       render(conn, "show.json", module: module)
     end
   end
 
   def delete(conn, %{"module_name" => name}) do
-    module = Modules.get_module_by_name!(name)
-
-    with {:ok, %Module{}} <- Modules.delete_module(module) do
+    with {:ok, module} <- Modules.get_module_by_name(name),
+         {:ok, %Module{}} <- Modules.delete_module(module) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/apps/core/test/core/integration/connectors/manager_test.exs
+++ b/apps/core/test/core/integration/connectors/manager_test.exs
@@ -78,11 +78,5 @@ defmodule Core.Integration.Connectors.ManagerTest do
       assert !Process.alive?(p1)
       assert !Process.alive?(p2)
     end
-
-    test "disconnect/1 should return {:error, :not_found} when trying to disconnect a function with no associated events",
-         %{func: func} do
-      result = Manager.disconnect(func)
-      assert {:error, :not_found} == result
-    end
   end
 end

--- a/apps/core/test/core/integration/modules_test.exs
+++ b/apps/core/test/core/integration/modules_test.exs
@@ -30,9 +30,9 @@ defmodule Core.ModulesTest do
       assert Modules.list_modules() == [module]
     end
 
-    test "get_module_by_name!/1 returns the module with given name" do
+    test "get_module_by_name/1 returns the module with given name" do
       module = module_fixture()
-      assert Modules.get_module_by_name!(module.name) == module
+      assert {:ok, module} = Modules.get_module_by_name(module.name)
     end
 
     test "get_functions_in_module!/1 returns the list of functions" do
@@ -66,13 +66,13 @@ defmodule Core.ModulesTest do
     test "update_module/2 with invalid data returns error changeset" do
       module = module_fixture()
       assert {:error, %Ecto.Changeset{}} = Modules.update_module(module, @invalid_attrs)
-      assert module == Modules.get_module_by_name!(module.name)
+      assert {:ok, module} = Modules.get_module_by_name(module.name)
     end
 
     test "delete_module/1 deletes the module" do
       module = module_fixture()
       assert {:ok, %Module{}} = Modules.delete_module(module)
-      assert_raise Ecto.NoResultsError, fn -> Modules.get_module_by_name!(module.name) end
+      assert {:error, :not_found} = Modules.get_module_by_name(module.name)
     end
 
     test "delete_module/1 also deletes all functions" do

--- a/apps/core/test/core/integration/modules_test.exs
+++ b/apps/core/test/core/integration/modules_test.exs
@@ -32,7 +32,7 @@ defmodule Core.ModulesTest do
 
     test "get_module_by_name/1 returns the module with given name" do
       module = module_fixture()
-      assert {:ok, module} = Modules.get_module_by_name(module.name)
+      assert {:ok, _module} = Modules.get_module_by_name(module.name)
     end
 
     test "get_functions_in_module!/1 returns the list of functions" do
@@ -66,7 +66,7 @@ defmodule Core.ModulesTest do
     test "update_module/2 with invalid data returns error changeset" do
       module = module_fixture()
       assert {:error, %Ecto.Changeset{}} = Modules.update_module(module, @invalid_attrs)
-      assert {:ok, module} = Modules.get_module_by_name(module.name)
+      assert {:ok, _module} = Modules.get_module_by_name(module.name)
     end
 
     test "delete_module/1 deletes the module" do


### PR DESCRIPTION
This PR adds some fixes and closes #156 

The events and sinks managers were returning {:error, :not_found} when disconnecting from a function and that function had and no events/sinks attached. This would in turn be returned from the controller resulting in a 404 response. Not it simply applies the disconnecting logic to the list of events/sinks without returning anything.

Another fix is the usage of the module get by name which was raising an exception if not found, instead not it returns an {:error, :not_found} that can be handled by the controller.