### PR TITLE
Add codeowners and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# FunLess team members
+* @giusdp @mattrent

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,63 @@
+<!--
+  ~ Copyright 2023 Giuseppe De Palma, Matteo Trentin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+---
+name: Bug report
+about: Create a new bug report
+title: "[BUG] <Issue>"
+labels: bug, help wanted
+assignees: ''
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Run command '...'
+1. Run other command '...'
+1. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Environment (please complete the following information)**
+ - OS: [e.g. Linux, MacOS, Windows]
+ - Arch: [e.g. x86_64, aarch64]
+ - FunLess Version or commit hash: [e.g. 0.7.0]
+
+If you encountered a bug while developing for FunLess, it might be helpful to specify the Elixir/OTP and rust versions:
+ - Output of `elixir --version` e.g.:
+ ```
+ Erlang/OTP 24 [erts-12.3.1] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [dtrace]
+
+Elixir 1.13.3 (compiled with Erlang/OTP 24)
+ ```
+ - Output of `cargo --version` e.g.:
+ ```
+ cargo 1.60.0 (d1fd9fe2c 2022-03-01)
+ ```
+
+**Screenshots**
+
+If applicable. They can help explain your problem.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright 2023 Giuseppe De Palma, Matteo Trentin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+---
+name: Feature request
+about: Suggest an idea
+title: "[FEATURE] <feature name>"
+labels: enhancement, help wanted
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds the CODEOWNERS file with my handle and @mattrent so that new PRs are automatically assigned reviewers.
It also adds 2 issue templates: one for bugs and one for features. This way we can start standardizing some issue categories