### PR TITLE
New repo for subjects database

### DIFF
--- a/apps/core/lib/application.ex
+++ b/apps/core/lib/application.ex
@@ -39,6 +39,7 @@ defmodule Core.Application do
       # {CoreWeb.Worker, arg}
       ## Core Children
       Core.Repo,
+      Core.SubjectsRepo,
       {Cluster.Supervisor, [topologies, [name: Core.ClusterSupervisor]]},
       {Core.Adapters.Telemetry.Supervisor, []},
       {Core.Adapters.Connectors.Supervisor, []},

--- a/apps/core/lib/core/subjects_repo.ex
+++ b/apps/core/lib/core/subjects_repo.ex
@@ -1,0 +1,22 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.SubjectsRepo do
+  @moduledoc """
+  The subjects repository.
+  """
+  use Ecto.Repo,
+    otp_app: :core,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,20 @@ import Config
 
 config :libcluster, debug: false
 
-# Configure your database
 config :core, Core.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
   database: "core_dev",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10
+
+config :core, Core.SubjectsRepo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "subjects_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/runtime_core.exs
+++ b/config/runtime_core.exs
@@ -1,4 +1,4 @@
-# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ if config_env() == :prod do
     username: System.get_env("PGUSER") || "postgres",
     password: System.get_env("PGPASSWORD") || "postgres",
     database: System.get_env("PGDATABASE") || "funless",
+    hostname: System.get_env("PGHOST") || "postgres",
+    port: System.get_env("PGPORT") || "5432",
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+    socket_options: maybe_ipv6
+
+  config :core, Core.SubjectsRepo,
+    # ssl: true,
+    username: System.get_env("PGUSER") || "postgres",
+    password: System.get_env("PGPASSWORD") || "postgres",
+    database: System.get_env("PGDATABASE") || "subjects",
     hostname: System.get_env("PGHOST") || "postgres",
     port: System.get_env("PGPORT") || "5432",
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,14 @@ config :core, Core.Repo,
   password: "postgres",
   hostname: "localhost",
   database: "core_test#{System.get_env("MIX_TEST_PARTITION")}",
+  pool: Ecto.Adapters.SQL.Sandbox,
+  pool_size: 10
+
+config :core, Core.SubjectsRepo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "subjects_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 10
 


### PR DESCRIPTION
This PR kickstarts the work for the Authentication&Authorization milestone. 

The current approach to implement such features is by using a second database: the "Subjects" database. It will store (User, Tokens) pairs that can be created by an admin user (inspired by the OpenWhisk model). 

I will try to make small but many PRs to get this done, starting from adding a new Repo to interact with the new DB.