### PR TITLE
Remove header from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,24 +4,7 @@ about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
 assignees: ''
-
 ---
-
-<!--
-  ~ Copyright 2023 Giuseppe De Palma, Matteo Trentin
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
--->
 
 **Describe the bug**
 


### PR DESCRIPTION
A small fix for the bug template to not have the entire license header in the text when creating a new bug issue.