### PR TITLE
Add phx.token and auth plug

### DIFF
--- a/apps/core/lib/core_web/auth.ex
+++ b/apps/core/lib/core_web/auth.ex
@@ -1,0 +1,44 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule CoreWeb.Plug.Authenticate do
+  @moduledoc """
+  Plug to authenticate a user by token.
+  """
+  import Plug.Conn
+  require Logger
+
+  alias Core.Domain.Subjects
+  alias CoreWeb.Token
+
+  def init(opts) do
+    opts
+  end
+
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, %{user: name}} <- Token.verify(token),
+         user when not is_nil(user) <- Subjects.get_subject_by_name(name) do
+      assign(conn, :current_user, user)
+    else
+      _error ->
+        conn
+        |> put_status(:unauthorized)
+        |> Phoenix.Controller.put_view(CoreWeb.ErrorView)
+        |> Phoenix.Controller.render(:"401")
+        |> halt()
+    end
+  end
+end

--- a/apps/core/lib/core_web/controllers/subject_controller.ex
+++ b/apps/core/lib/core_web/controllers/subject_controller.ex
@@ -15,6 +15,8 @@
 defmodule CoreWeb.SubjectController do
   use CoreWeb, :controller
 
+  require Logger
+
   alias Core.Domain.Subjects
   alias Core.Schemas.Subject
 
@@ -25,8 +27,11 @@ defmodule CoreWeb.SubjectController do
     render(conn, "index.json", subjects: subjects)
   end
 
-  def create(conn, %{"subject" => subject_params}) do
-    with {:ok, %Subject{} = subject} <- Subjects.create_subject(subject_params) do
+  def create(conn, %{"subject" => %{"name" => name}}) do
+    signed_token = CoreWeb.Token.sign(%{user: name})
+
+    with {:ok, %Subject{} = subject} <-
+           Subjects.create_subject(%{name: name, token: signed_token}) do
       conn
       |> put_status(:created)
       |> render("show.json", subject: subject)
@@ -38,19 +43,19 @@ defmodule CoreWeb.SubjectController do
     render(conn, "show.json", subject: subject)
   end
 
-  def update(conn, %{"id" => id, "subject" => subject_params}) do
-    subject = Subjects.get_subject!(id)
+  # def update(conn, %{"id" => id, "subject" => subject_params}) do
+  #   subject = Subjects.get_subject!(id)
 
-    with {:ok, %Subject{} = subject} <- Subjects.update_subject(subject, subject_params) do
-      render(conn, "show.json", subject: subject)
-    end
-  end
+  #   with {:ok, %Subject{} = subject} <- Subjects.update_subject(subject, subject_params) do
+  #     render(conn, "show.json", subject: subject)
+  #   end
+  # end
 
-  def delete(conn, %{"id" => id}) do
-    subject = Subjects.get_subject!(id)
+  # def delete(conn, %{"id" => id}) do
+  #   subject = Subjects.get_subject!(id)
 
-    with {:ok, %Subject{}} <- Subjects.delete_subject(subject) do
-      send_resp(conn, :no_content, "")
-    end
-  end
+  #   with {:ok, %Subject{}} <- Subjects.delete_subject(subject) do
+  #     send_resp(conn, :no_content, "")
+  #   end
+  # end
 end

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -19,16 +19,23 @@ defmodule CoreWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :authenticated do
+    plug(CoreWeb.Plug.Authenticate)
+  end
+
+  # Endpoints without authentication
   scope "/v1", CoreWeb do
     pipe_through(:api)
 
     # A simple get "/" to health check
     get("/", DefaultController, :index)
 
-    # Admin routes (Subjects)
-    resources("/admin/subjects", SubjectController, except: [:new, :edit])
+    get("/admin/subjects", SubjectController, :index)
+    post("/admin/subjects", SubjectController, :create)
+  end
 
-    # --- Public API routes ---
+  scope "/v1", CoreWeb do
+    pipe_through([:api, :authenticated])
 
     # List all modules
     get("/fn", ModuleController, :index)

--- a/apps/core/lib/core_web/token.ex
+++ b/apps/core/lib/core_web/token.ex
@@ -1,0 +1,43 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule CoreWeb.Token do
+  @moduledoc """
+  Token module for signing and verifying tokens
+  """
+  @signing_salt "funless_api"
+  # token for 2 week
+  @token_age_secs 14 * 86_400
+
+  @doc """
+  Create token for given data
+  """
+  @spec sign(map()) :: binary()
+  def sign(data) do
+    Phoenix.Token.sign(CoreWeb.Endpoint, @signing_salt, data)
+  end
+
+  @doc """
+  Verify given token by:
+  - Verify token signature
+  - Verify expiration time
+  """
+  @spec verify(String.t()) :: {:ok, any()} | {:error, :unauthenticated}
+  def verify(token) do
+    case Phoenix.Token.verify(CoreWeb.Endpoint, @signing_salt, token, max_age: @token_age_secs) do
+      {:ok, data} -> {:ok, data}
+      _error -> {:error, :unauthenticated}
+    end
+  end
+end

--- a/apps/core/lib/mix/tasks/ecto.setup.ex
+++ b/apps/core/lib/mix/tasks/ecto.setup.ex
@@ -39,8 +39,5 @@ defmodule Mix.Tasks.Ecto.Setup do
     Mix.shell().info("Performing migrations...")
     Mix.Task.run("ecto.migrate", [])
     Mix.Task.rerun("ecto.migrate", ["-r", "Core.SubjectsRepo"])
-    Mix.shell().info("Seeding databases...")
-    # Mix.Task.run("run", ["apps/core/priv/repo/seeds/seeds.exs"])
-    # Mix.Task.rerun("run", ["apps/core/priv/subjects_repo/seeds/subjects_seeds.exs"])
   end
 end

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -79,7 +79,10 @@ defmodule Core.MixProject do
     [
       setup: ["deps.get", "ecto.setup"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "ecto.seed": ["run priv/repo/seeds/seeds.exs"],
+      "ecto.seed": [
+        "run priv/repo/seeds/seeds.exs",
+        "run priv/subjects_repo/seeds/seeds.exs"
+      ],
       "test.integration": ["test --only integration_test"]
     ]
   end

--- a/apps/core/priv/subjects_repo/seeds/seeds.exs
+++ b/apps/core/priv/subjects_repo/seeds/seeds.exs
@@ -1,0 +1,31 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script for populating the database. You can run it as:
+#
+#     mix run priv/repo/seeds.exs
+#
+# Inside the script, you can read and write to any of your
+# repositories directly:
+#
+#     Core.Repo.insert!(%Core.SomeSchema{})
+#
+# We recommend using the bang functions (`insert!`, `update!`
+# and so on) as they will fail if something goes wrong.
+
+alias Core.SubjectsRepo
+alias Core.Schemas.Subject
+
+signed_token = CoreWeb.Token.sign(%{user: "guest"})
+SubjectsRepo.insert!(%Subject{name: "guest", token: signed_token})

--- a/apps/core/test/core/integration/subjects_test.exs
+++ b/apps/core/test/core/integration/subjects_test.exs
@@ -26,7 +26,7 @@ defmodule Core.SubjectsTest do
 
     test "list_subjects/0 returns all subjects" do
       subject = subject_fixture()
-      assert Subjects.list_subjects() == [subject]
+      assert [_, ^subject] = Subjects.list_subjects()
     end
 
     test "get_subject!/1 returns the subject with given id" do

--- a/apps/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -18,6 +18,7 @@ defmodule CoreWeb.FunctionControllerTest do
   require Logger
   import Core.{FunctionsFixtures, ModulesFixtures}
 
+  alias Core.Domain.Subjects
   alias Core.Schemas.Function
 
   @create_attrs %{
@@ -76,7 +77,14 @@ defmodule CoreWeb.FunctionControllerTest do
     Core.Connectors.Manager.Mock |> Mox.stub_with(Core.Adapters.Connectors.Test)
     Core.DataSinks.Manager.Mock |> Mox.stub_with(Core.Adapters.DataSinks.Test)
 
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    user = Subjects.get_subject_by_name("guest")
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{user.token}")
+
+    {:ok, conn: conn}
   end
 
   describe "create function" do

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -19,6 +19,7 @@ defmodule CoreWeb.ModuleControllerTest do
   import Core.ModulesFixtures
   import Core.FunctionsFixtures
   alias Core.Schemas.Module
+  alias Ecto.Adapters.SQL.Sandbox
 
   @create_attrs %{
     name: "some_name"
@@ -29,6 +30,7 @@ defmodule CoreWeb.ModuleControllerTest do
   @invalid_attrs %{name: nil}
 
   setup %{conn: conn} do
+    :ok = Sandbox.checkout(Core.SubjectsRepo)
     user = Subjects.get_subject_by_name("guest")
 
     conn =

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -15,9 +15,9 @@
 defmodule CoreWeb.ModuleControllerTest do
   use CoreWeb.ConnCase
 
+  alias Core.Domain.Subjects
   import Core.ModulesFixtures
   import Core.FunctionsFixtures
-
   alias Core.Schemas.Module
 
   @create_attrs %{
@@ -29,7 +29,14 @@ defmodule CoreWeb.ModuleControllerTest do
   @invalid_attrs %{name: nil}
 
   setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    user = Subjects.get_subject_by_name("guest")
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{user.token}")
+
+    {:ok, conn: conn}
   end
 
   describe "lists" do

--- a/apps/core/test/core_web/integration/controllers/subject_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/subject_controller_test.exs
@@ -36,18 +36,17 @@ defmodule CoreWeb.SubjectControllerTest do
   describe "index" do
     test "lists all subjects", %{conn: conn} do
       conn = get(conn, Routes.subject_path(conn, :index))
-      assert json_response(conn, 200)["data"] == []
+
+      assert [
+               %{"name" => "guest", "token" => _t}
+             ] = json_response(conn, 200)["data"]
     end
   end
 
   describe "create subject" do
     test "renders subject when data is valid", %{conn: conn} do
       conn = post(conn, Routes.subject_path(conn, :create), subject: @create_attrs)
-
-      assert %{
-               "name" => "some_name",
-               "token" => "some_token"
-             } = json_response(conn, 201)["data"]
+      assert %{"name" => "some_name", "token" => _} = json_response(conn, 201)["data"]
     end
 
     test "renders errors when data is invalid", %{conn: conn} do

--- a/mix.exs
+++ b/mix.exs
@@ -69,9 +69,11 @@ defmodule Core.Umbrella.MixProject do
     [
       # run `mix setup` in all child apps
       setup: "cmd mix setup",
+      "ecto.seed": "cmd --app core mix ecto.seed",
       "core.utest": "cmd --app core mix test --color",
       "core.itest": [
         "ecto.setup --quiet",
+        "run apps/core/priv/subjects_repo/seeds/seeds.exs",
         "cmd --app core mix test.integration --color"
       ],
       "worker.utest": "cmd --app worker mix test --color"


### PR DESCRIPTION
This PR adds:

- a Token module to generate and verify jwts.
- an auth plug which expects an authorization header with a bearer token and verifies the input tokens.
- the subjects controller on creation generates a token and stores the (name,token) pair in the DB. 
- the router now adds the auth plug in the pipeline and all endpoints (save for /admin) are piped through that, so there needs to be a valid Bearer token in each request.
- the subject DB is seeded with a "guest" subject, which generates a token for it.
- the tests that use the controllers are updated with the auth header using the guest token