### PR TITLE
More checks on token in request

### DIFF
--- a/apps/core/lib/core_web/auth.ex
+++ b/apps/core/lib/core_web/auth.ex
@@ -30,7 +30,9 @@ defmodule CoreWeb.Plug.Authenticate do
   def call(conn, _opts) do
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
          {:ok, %{user: name}} <- Token.verify(token),
-         user when not is_nil(user) <- Subjects.get_subject_by_name(name) do
+         user when not is_nil(user) <- Subjects.get_subject_by_name(name),
+         {:ok, %{user: saved_name}} <- Token.verify(user.token),
+         true <- user.token == token && name == saved_name do
       assign(conn, :current_user, user)
     else
       _error ->


### PR DESCRIPTION
This PR closes #182 

The PR adds more checks for token verification. It verifies the saved token to check it's still valid and compares the input token with the saved one.