### PR TITLE
Cache between subject db and auth check

### DIFF
--- a/apps/core/lib/application.ex
+++ b/apps/core/lib/application.ex
@@ -41,6 +41,7 @@ defmodule Core.Application do
       Core.Repo,
       Core.SubjectsRepo,
       {Cluster.Supervisor, [topologies, [name: Core.ClusterSupervisor]]},
+      {Core.Adapters.Subjects.Cache, []},
       {Core.Adapters.Telemetry.Supervisor, []},
       {Core.Adapters.Connectors.Supervisor, []},
       {Core.Adapters.DataSinks.Supervisor, []}

--- a/apps/core/lib/core/adapters/subjects/cache.ex
+++ b/apps/core/lib/core/adapters/subjects/cache.ex
@@ -1,0 +1,100 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Subjects.Cache do
+  @moduledoc """
+  A GenServer that implements a cache for subjects and tokens.
+
+  The cache is implemented as an ETS table, accessed through a GenServer.
+  """
+  @behaviour Core.Domain.Ports.SubjectCache
+
+  use GenServer, restart: :permanent
+  require Logger
+
+  @subjects_cache_server :subjects_cache_server
+  @subjects_cache_table :subjects_cache
+
+  @doc """
+  Retrieve a token from the cache, associated to a subject.
+
+  ## Parameters
+  - `subject`: the subject name string
+
+  ## Returns
+  - `token` if the token is found;
+  - `:subject_not_found` if the token is not found.
+  """
+  @impl true
+  def get(subject) do
+    case :ets.lookup(@subjects_cache_table, subject) do
+      [{^subject, token}] -> token
+      _ -> :subject_not_found
+    end
+  end
+
+  @doc """
+  Store a token in the cache, associated to a subject.
+
+  ## Parameters
+  - `subject`: the subject name string
+  - `token`: the token to store
+
+  ## Returns
+  - `:ok`
+  """
+  @impl true
+  def insert(subject, token) do
+    GenServer.call(@subjects_cache_server, {:insert, subject, token})
+  end
+
+  @doc """
+  Delete a token from the cache, associated to a subject.
+
+  ## Parameters
+  - `subject`: the subject name string
+
+  ## Returns
+  - `:ok`
+  """
+  @impl true
+  def delete(subject) do
+    GenServer.call(@subjects_cache_server, {:delete, subject})
+  end
+
+  # GenServer callbacks
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: @subjects_cache_server)
+  end
+
+  @impl true
+  def init(_args) do
+    table = :ets.new(@subjects_cache_table, [:set, :named_table, :protected])
+    {:ok, table}
+  end
+
+  @impl true
+  def handle_call({:insert, name, token}, _from, table) do
+    :ets.insert(table, {name, token})
+    Logger.info("Subjects Cache: added subject #{name}.")
+    {:reply, :ok, table}
+  end
+
+  @impl true
+  def handle_call({:delete, name}, _from, table) do
+    :ets.delete(table, name)
+    Logger.info("Subject Cache: removes subject #{name}.")
+    {:reply, :ok, table}
+  end
+end

--- a/apps/core/lib/core/adapters/subjects/test.ex
+++ b/apps/core/lib/core/adapters/subjects/test.ex
@@ -1,0 +1,35 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.Subjects.Cache.Test do
+  @moduledoc """
+  Test adapter for the SubjectCache behaviour.
+  """
+  @behaviour Core.Domain.Ports.SubjectCache
+
+  @impl true
+  def get(_subject) do
+    "subject"
+  end
+
+  @impl true
+  def insert(_subject, _token) do
+    :ok
+  end
+
+  @impl true
+  def delete(_subject) do
+    :ok
+  end
+end

--- a/apps/core/lib/core/domain/ports/subject_cache.ex
+++ b/apps/core/lib/core/domain/ports/subject_cache.ex
@@ -1,0 +1,41 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Ports.SubjectCache do
+  @moduledoc """
+  Port for the SubjectCache behaviour.
+  The SubjectCache is a cache that stores the token associated to a subject.
+  """
+
+  @callback get(String.t()) :: String.t() | :subject_not_found
+  @callback insert(String.t(), String.t()) :: :ok | {:error, any}
+  @callback delete(String.t()) :: :ok | {:error, any}
+
+  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @doc """
+  """
+  @spec get(String.t()) :: String.t() | :subject_not_found
+  defdelegate get(subject_name), to: @adapter
+
+  @doc """
+  """
+  @spec insert(String.t(), String.t()) :: :ok | {:error, any}
+  defdelegate insert(subject_name, token), to: @adapter
+
+  @doc """
+  """
+  @spec delete(String.t()) :: :ok | {:error, any}
+  defdelegate delete(subject_name), to: @adapter
+end

--- a/apps/core/test/core/unit/subject_cache_test.exs
+++ b/apps/core/test/core/unit/subject_cache_test.exs
@@ -1,0 +1,41 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Integration.SubjectCacheTest do
+  use ExUnit.Case
+
+  alias Core.Adapters.Subjects.Cache
+
+  import Mox, only: [verify_on_exit!: 1]
+
+  setup :verify_on_exit!
+
+  test "SubjectCache get returns a :subject_not_found when no subject" do
+    result = Cache.get("non-existent-subject")
+    assert result == :subject_not_found
+  end
+
+  test "insert adds subject => token into the cache" do
+    token = "some-token"
+    assert Cache.get("test") == :subject_not_found
+    assert :ok = Cache.insert("test", token)
+    assert Cache.get("test") == token
+    assert :ok = Cache.delete("test")
+  end
+
+  test "delete on empty empty does nothing" do
+    assert Cache.get("test") == :subject_not_found
+    assert :ok = Cache.delete("test")
+  end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,7 @@ config :core, Core.Domain.Ports.Cluster, adapter: Core.Adapters.Cluster
 config :core, Core.Domain.Ports.Telemetry.Metrics, adapter: Core.Adapters.Telemetry.Metrics
 config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Connectors.Manager
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
+config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
 
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]


### PR DESCRIPTION
This PR tackles #183 by adding an ETS table to store subject names/tokens that is used during auth check. If the subject name is not found in the table it falls back to querying the DB. If found the pair is added to the cache for future use.

It's a first implementation to have something working but it we should add a cache eviction policy soon.