### PR TITLE
Add Admin auth check on `/subjects` endpoints

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -14,10 +14,10 @@
 
 # The version of Alpine to use for the final image
 # This should match the version of Alpine that the `elixir:1.14-alpine` image uses
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.17
 ARG SECRET_KEY_BASE
 
-FROM elixir:1.13-alpine AS builder
+FROM elixir:1.14-alpine AS builder
 
 ARG MIX_ENV=prod
 
@@ -33,11 +33,6 @@ RUN apk update && \
     apk add --no-cache git build-base bash curl openssl ncurses-libs libgcc && \
     mix local.rebar --force && \
     mix local.hex --force
-
-# Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-ENV RUSTFLAGS='--codegen target-feature=-crt-static'
 
 # This copies our app source code into the build container
 COPY . .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -14,9 +14,9 @@
 
 # The version of Alpine to use for the final image
 # This should match the version of Alpine that the `elixir:1.13.4-alpine` image uses
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.17
 
-FROM elixir:1.13-alpine AS builder
+FROM elixir:1.14-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)
@@ -34,11 +34,6 @@ RUN apk update && \
     apk add --no-cache git build-base bash curl openssl ncurses-libs libgcc && \
     mix local.rebar --force && \
     mix local.hex --force
-
-# Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-ENV RUSTFLAGS='--codegen target-feature=-crt-static'
 
 # This copies our app source code into the build container
 COPY . .

--- a/apps/core/lib/core/domain/admins.ex
+++ b/apps/core/lib/core/domain/admins.ex
@@ -4,7 +4,7 @@ defmodule Core.Domain.Admins do
   """
 
   import Ecto.Query, warn: false
-  alias Core.Repo
+  alias Core.SubjectsRepo, as: Repo
 
   alias Core.Schemas.Admin
 

--- a/apps/core/lib/core/domain/admins.ex
+++ b/apps/core/lib/core/domain/admins.ex
@@ -1,0 +1,121 @@
+defmodule Core.Domain.Admins do
+  @moduledoc """
+  The Subjects context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Core.Repo
+
+  alias Core.Schemas.Admin
+
+  @doc """
+  Returns the list of admins.
+
+  ## Examples
+
+      iex> list_admins()
+      [%Admin{}, ...]
+
+  """
+  def list_admins do
+    Repo.all(Admin)
+  end
+
+  @doc """
+  Gets a single admin.
+
+  Raises `Ecto.NoResultsError` if the Admin does not exist.
+
+  ## Examples
+
+      iex> get_admin!(123)
+      %Admin{}
+
+      iex> get_admin!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_admin!(id), do: Repo.get!(Admin, id)
+
+  @doc """
+  Gets a single admin by name.
+
+  Returns `nil` if the Admin does not exist.
+
+  ## Examples
+
+      iex> get_admin_by_name("name")
+      %Admin{}
+
+      iex> get_admin_by_name("not_found")
+      nil
+  """
+  def get_admin_by_name(name) do
+    Repo.get_by(Admin, name: name)
+  end
+
+  @doc """
+  Creates a admin.
+
+  ## Examples
+
+      iex> create_admin(%{field: value})
+      {:ok, %Admin{}}
+
+      iex> create_admin(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_admin(attrs \\ %{}) do
+    %Admin{}
+    |> Admin.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a admin.
+
+  ## Examples
+
+      iex> update_admin(admin, %{field: new_value})
+      {:ok, %Admin{}}
+
+      iex> update_admin(admin, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_admin(%Admin{} = admin, attrs) do
+    admin
+    |> Admin.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a admin.
+
+  ## Examples
+
+      iex> delete_admin(admin)
+      {:ok, %Admin{}}
+
+      iex> delete_admin(admin)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_admin(%Admin{} = admin) do
+    Repo.delete(admin)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking admin changes.
+
+  ## Examples
+
+      iex> change_admin(admin)
+      %Ecto.Changeset{data: %Admin{}}
+
+  """
+  def change_admin(%Admin{} = admin, attrs \\ %{}) do
+    Admin.changeset(admin, attrs)
+  end
+end

--- a/apps/core/lib/core/domain/admins.ex
+++ b/apps/core/lib/core/domain/admins.ex
@@ -1,6 +1,20 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defmodule Core.Domain.Admins do
   @moduledoc """
-  The Subjects context.
+  The Admins context.
   """
 
   import Ecto.Query, warn: false

--- a/apps/core/lib/core/schemas/admin.ex
+++ b/apps/core/lib/core/schemas/admin.ex
@@ -1,0 +1,42 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Schemas.Admin do
+  @moduledoc """
+  The Admin schema
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "admins" do
+    field(:name, :string)
+    field(:token, :string, redact: true)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(admin, attrs) do
+    # only allow valid letters, numbers and underscores in the middle
+    regex = ~r/^[_a-zA-Z0-9]+$/
+    msg = "must contain only alphanumeric characters and underscores"
+
+    admin
+    |> cast(attrs, [:name, :token])
+    |> validate_required([:name, :token])
+    |> validate_format(:name, regex, message: msg)
+    |> validate_length(:name, min: 1, max: 160)
+    |> unique_constraint(:name)
+  end
+end

--- a/apps/core/lib/core_web/auth_admin.ex
+++ b/apps/core/lib/core_web/auth_admin.ex
@@ -1,0 +1,57 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule CoreWeb.Plug.AuthenticateAdmin do
+  @moduledoc """
+  Plug to authenticate an admin user by token.
+  """
+  import Plug.Conn
+  require Logger
+
+  alias Core.Domain.Admins
+  alias CoreWeb.Token
+
+  def init(opts) do
+    opts
+  end
+
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, %{user: name}} <- Token.verify(token),
+         {:ok, stored_token} <- retrieve_admin(name),
+         {:ok, %{user: stored_name}} <- Token.verify(stored_token),
+         true <- stored_token == token && name == stored_name do
+      assign(conn, :current_user, name)
+    else
+      _error ->
+        conn
+        |> put_status(:unauthorized)
+        |> Phoenix.Controller.put_view(CoreWeb.ErrorView)
+        |> Phoenix.Controller.render(:"401")
+        |> halt()
+    end
+  end
+
+  @spec retrieve_admin(String.t()) :: {:ok, any()} | {:error, any()}
+  defp retrieve_admin(name) do
+    case Admins.get_admin_by_name(name) do
+      nil ->
+        {:error, :admin_not_found}
+
+      user ->
+        {:ok, user.token}
+    end
+  end
+end

--- a/apps/core/lib/core_web/router.ex
+++ b/apps/core/lib/core_web/router.ex
@@ -23,12 +23,20 @@ defmodule CoreWeb.Router do
     plug(CoreWeb.Plug.Authenticate)
   end
 
+  pipeline :admin do
+    plug(CoreWeb.Plug.AuthenticateAdmin)
+  end
+
   # Endpoints without authentication
   scope "/v1", CoreWeb do
     pipe_through(:api)
 
     # A simple get "/" to health check
     get("/", DefaultController, :index)
+  end
+
+  scope "/v1", CoreWeb do
+    pipe_through([:api, :admin])
 
     get("/admin/subjects", SubjectController, :index)
     post("/admin/subjects", SubjectController, :create)

--- a/apps/core/lib/core_web/token.ex
+++ b/apps/core/lib/core_web/token.ex
@@ -25,7 +25,14 @@ defmodule CoreWeb.Token do
   """
   @spec sign(map()) :: binary()
   def sign(data) do
-    Phoenix.Token.sign(CoreWeb.Endpoint, @signing_salt, data)
+    try do
+      Phoenix.Token.sign(CoreWeb.Endpoint, @signing_salt, data)
+    rescue
+      # if the ETS table does not exist (i.e. the application is not running), we pass the secret key itself as an argument
+      _ in ArgumentError ->
+        key_base = System.fetch_env!("SECRET_KEY_BASE")
+        Phoenix.Token.sign(key_base, @signing_salt, data)
+    end
   end
 
   @doc """

--- a/apps/core/lib/core_web/token.ex
+++ b/apps/core/lib/core_web/token.ex
@@ -25,14 +25,13 @@ defmodule CoreWeb.Token do
   """
   @spec sign(map()) :: binary()
   def sign(data) do
-    try do
-      Phoenix.Token.sign(CoreWeb.Endpoint, @signing_salt, data)
-    rescue
-      # if the ETS table does not exist (i.e. the application is not running), we pass the secret key itself as an argument
-      _ in ArgumentError ->
-        key_base = System.fetch_env!("SECRET_KEY_BASE")
-        Phoenix.Token.sign(key_base, @signing_salt, data)
-    end
+    Phoenix.Token.sign(CoreWeb.Endpoint, @signing_salt, data)
+  rescue
+    # if the ETS table does not exist (i.e. the application is not running),
+    # we pass the secret key itself as an argument
+    _ in ArgumentError ->
+      key_base = System.fetch_env!("SECRET_KEY_BASE")
+      Phoenix.Token.sign(key_base, @signing_salt, data)
   end
 
   @doc """

--- a/apps/core/priv/subjects_repo/migrations/20230318184753_create_admins.exs
+++ b/apps/core/priv/subjects_repo/migrations/20230318184753_create_admins.exs
@@ -1,0 +1,28 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.SubjectsRepo.Migrations.CreateAdmins do
+  use Ecto.Migration
+
+  def change do
+    create table(:admins) do
+      add :name, :string
+      add :token, :string
+
+      timestamps()
+    end
+
+    create unique_index(:admins, [:name])
+  end
+end

--- a/apps/core/priv/subjects_repo/seeds/seeds.exs
+++ b/apps/core/priv/subjects_repo/seeds/seeds.exs
@@ -26,9 +26,17 @@
 
 alias Core.SubjectsRepo
 alias Core.Schemas.Subject
+alias Core.Schemas.Admin
 
 signed_token = CoreWeb.Token.sign(%{user: "guest"})
 SubjectsRepo.insert!(%Subject{name: "guest", token: signed_token})
 
 admin_token = CoreWeb.Token.sign(%{user: "admin"})
-SubjectsRepo.insert!(%Admin{name: "admin", token: signed_token})
+SubjectsRepo.insert!(%Admin{name: "admin", token: admin_token})
+
+
+file_path = :core |> Application.compile_env!(Core.Seeds) |> Keyword.fetch!(:path)
+
+with :ok <- File.mkdir_p(Path.dirname(file_path)) do
+  File.write(file_path, "Admin=#{admin_token}\nGuest=#{signed_token}")
+end

--- a/apps/core/priv/subjects_repo/seeds/seeds.exs
+++ b/apps/core/priv/subjects_repo/seeds/seeds.exs
@@ -29,3 +29,6 @@ alias Core.Schemas.Subject
 
 signed_token = CoreWeb.Token.sign(%{user: "guest"})
 SubjectsRepo.insert!(%Subject{name: "guest", token: signed_token})
+
+admin_token = CoreWeb.Token.sign(%{user: "admin"})
+SubjectsRepo.insert!(%Admin{name: "admin", token: signed_token})

--- a/apps/core/test/core/integration/admins_test.exs
+++ b/apps/core/test/core/integration/admins_test.exs
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 defmodule Core.AdminsTest do
-  use Core.DataCase
+  use Core.SubjectsDataCase
 
   alias Core.Domain.Admins
 
@@ -26,7 +26,7 @@ defmodule Core.AdminsTest do
 
     test "list_admins/0 returns all admins" do
       admin = admin_fixture()
-      assert Admins.list_admins() == [admin]
+      assert [_, ^admin] = Admins.list_admins()
     end
 
     test "get_admin!/1 returns the admin with given id" do
@@ -35,11 +35,11 @@ defmodule Core.AdminsTest do
     end
 
     test "create_admin/1 with valid data creates a admin" do
-      valid_attrs = %{name: "some name", token: "some token"}
+      valid_attrs = %{name: "some_name", token: "some_token"}
 
       assert {:ok, %Admin{} = admin} = Admins.create_admin(valid_attrs)
-      assert admin.name == "some name"
-      assert admin.token == "some token"
+      assert admin.name == "some_name"
+      assert admin.token == "some_token"
     end
 
     test "create_admin/1 with invalid data returns error changeset" do
@@ -48,11 +48,11 @@ defmodule Core.AdminsTest do
 
     test "update_admin/2 with valid data updates the admin" do
       admin = admin_fixture()
-      update_attrs = %{name: "some updated name", token: "some updated token"}
+      update_attrs = %{name: "some_updated_name", token: "some_updated_token"}
 
       assert {:ok, %Admin{} = admin} = Admins.update_admin(admin, update_attrs)
-      assert admin.name == "some updated name"
-      assert admin.token == "some updated token"
+      assert admin.name == "some_updated_name"
+      assert admin.token == "some_updated_token"
     end
 
     test "update_admin/2 with invalid data returns error changeset" do

--- a/apps/core/test/core/integration/admins_test.exs
+++ b/apps/core/test/core/integration/admins_test.exs
@@ -1,0 +1,75 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.AdminsTest do
+  use Core.DataCase
+
+  alias Core.Domain.Admins
+
+  describe "admins" do
+    alias Core.Schemas.Admin
+
+    import Core.SubjectsFixtures
+
+    @invalid_attrs %{name: nil, token: nil}
+
+    test "list_admins/0 returns all admins" do
+      admin = admin_fixture()
+      assert Admins.list_admins() == [admin]
+    end
+
+    test "get_admin!/1 returns the admin with given id" do
+      admin = admin_fixture()
+      assert Admins.get_admin!(admin.id) == admin
+    end
+
+    test "create_admin/1 with valid data creates a admin" do
+      valid_attrs = %{name: "some name", token: "some token"}
+
+      assert {:ok, %Admin{} = admin} = Admins.create_admin(valid_attrs)
+      assert admin.name == "some name"
+      assert admin.token == "some token"
+    end
+
+    test "create_admin/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Admins.create_admin(@invalid_attrs)
+    end
+
+    test "update_admin/2 with valid data updates the admin" do
+      admin = admin_fixture()
+      update_attrs = %{name: "some updated name", token: "some updated token"}
+
+      assert {:ok, %Admin{} = admin} = Admins.update_admin(admin, update_attrs)
+      assert admin.name == "some updated name"
+      assert admin.token == "some updated token"
+    end
+
+    test "update_admin/2 with invalid data returns error changeset" do
+      admin = admin_fixture()
+      assert {:error, %Ecto.Changeset{}} = Admins.update_admin(admin, @invalid_attrs)
+      assert admin == Admins.get_admin!(admin.id)
+    end
+
+    test "delete_admin/1 deletes the admin" do
+      admin = admin_fixture()
+      assert {:ok, %Admin{}} = Admins.delete_admin(admin)
+      assert_raise Ecto.NoResultsError, fn -> Admins.get_admin!(admin.id) end
+    end
+
+    test "change_admin/1 returns a admin changeset" do
+      admin = admin_fixture()
+      assert %Ecto.Changeset{} = Admins.change_admin(admin)
+    end
+  end
+end

--- a/apps/core/test/core_web/integration/controllers/subject_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/subject_controller_test.exs
@@ -17,6 +17,7 @@ defmodule CoreWeb.SubjectControllerTest do
 
   import Core.SubjectsFixtures
 
+  alias Core.Domain.Admins
   alias Core.Schemas.Subject
 
   @create_attrs %{
@@ -31,6 +32,15 @@ defmodule CoreWeb.SubjectControllerTest do
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
+
+    admin = Admins.get_admin_by_name("admin")
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{admin.token}")
+
+    {:ok, conn: conn}
   end
 
   describe "index" do

--- a/apps/core/test/support/fixtures/subjects_fixtures.ex
+++ b/apps/core/test/support/fixtures/subjects_fixtures.ex
@@ -15,9 +15,10 @@
 defmodule Core.SubjectsFixtures do
   @moduledoc """
   This module defines test helpers for creating
-  entities via the `Core.Domain.Subjects` context.
+  entities via the `Core.Domain.Subjects` and `Core.Domain.Admins` contexts.
   """
   alias Core.Domain.Subjects
+  alias Core.Domain.Admins
 
   @doc """
   Generate a subject.
@@ -32,5 +33,20 @@ defmodule Core.SubjectsFixtures do
       |> Subjects.create_subject()
 
     subject
+  end
+
+  @doc """
+  Generate a admin.
+  """
+  def admin_fixture(attrs \\ %{}) do
+    {:ok, admin} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        token: "some token"
+      })
+      |> Admins.create_admin()
+
+    admin
   end
 end

--- a/apps/core/test/support/fixtures/subjects_fixtures.ex
+++ b/apps/core/test/support/fixtures/subjects_fixtures.ex
@@ -42,8 +42,8 @@ defmodule Core.SubjectsFixtures do
     {:ok, admin} =
       attrs
       |> Enum.into(%{
-        name: "some name",
-        token: "some token"
+        name: "some_name",
+        token: "some_token"
       })
       |> Admins.create_admin()
 

--- a/apps/core/test/support/fixtures/subjects_fixtures.ex
+++ b/apps/core/test/support/fixtures/subjects_fixtures.ex
@@ -17,8 +17,8 @@ defmodule Core.SubjectsFixtures do
   This module defines test helpers for creating
   entities via the `Core.Domain.Subjects` and `Core.Domain.Admins` contexts.
   """
-  alias Core.Domain.Subjects
   alias Core.Domain.Admins
+  alias Core.Domain.Subjects
 
   @doc """
   Generate a subject.

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,7 @@ config :core, Core.Domain.Ports.Telemetry.Metrics, adapter: Core.Adapters.Teleme
 config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Connectors.Manager
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
 config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
+config :core, Core.Domain.Ports.AdminCache, adapter: Core.Adapters.Admins.Cache
 
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]
@@ -53,6 +54,8 @@ config :core, CoreWeb.PromEx,
   drop_metrics_groups: [],
   metrics_server: :disabled,
   grafana: :disabled
+
+config :core, Core.Seeds, path: "/tmp/funless/tokens"
 
 # --- Worker Configs ---
 config :worker, Worker.Domain.Ports.Runtime.Provisioner,

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,6 @@ config :core, Core.Domain.Ports.Telemetry.Metrics, adapter: Core.Adapters.Teleme
 config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Connectors.Manager
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
 config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
-config :core, Core.Domain.Ports.AdminCache, adapter: Core.Adapters.Admins.Cache
 
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]

--- a/rel/overlays/bin/seed
+++ b/rel/overlays/bin/seed
@@ -14,4 +14,6 @@
 
 #!/bin/sh
 cd -P -- "$(dirname -- "$0")"
-exec ./core eval 'Core.Release.seed(Elixir.Core.Repo, "seeds.exs")'
+exec ./core eval 'Core.Release.seed(Elixir.Core.Repo, "seeds.exs");\
+ Plug.Crypto.Application.start(%{}, %{});\
+ Core.Release.seed(Elixir.Core.SubjectsRepo, "seeds.exs")'


### PR DESCRIPTION
This PR adds an authentication check on `/subjects` endpoints, using a special admin account. Previous endpoints keep the same authentication mechanism as before.

Specifically, the PR:
- adds the `admins` table and schema in `SubjectsRepo`, to contain admin accounts
- adds a token for the `admin` account when seeding the database, to ensure that at least on admin exists when the application runs
- saves the `admin` and `guest` tokens in a local file, readable by the user deploying the platform

Additionally:
- updates Elixir and Alpine versions in Dockerfiles
- removes Rust installation (unused) from Dockerfiles
- fixes `SubjectsRepo` seeding in Dockerfiles and releases, by starting `Plug.Crypto.Application` before generating the tokens