### PR TITLE
Return parsed error when fn already exists

### DIFF
--- a/apps/core/lib/core_web/controllers/fallback_controller.ex
+++ b/apps/core/lib/core_web/controllers/fallback_controller.ex
@@ -42,6 +42,13 @@ defmodule CoreWeb.FallbackController do
     |> render(:"400")
   end
 
+  def call(conn, {:error, :conflict}) do
+    conn
+    |> put_status(:conflict)
+    |> put_view(CoreWeb.ErrorView)
+    |> render(:"409")
+  end
+
   def call(conn, {:error, :no_workers}) do
     res = %{errors: %{detail: "No worker available"}}
 

--- a/apps/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -209,6 +209,20 @@ defmodule CoreWeb.FunctionControllerTest do
                "sinks_metadata" => %{"successful" => 1, "failed" => 1}
              } = json_response(conn, 207)["data"]
     end
+
+    test "error when module doesn't exist", %{conn: conn} do
+      conn = post(conn, Routes.function_path(conn, :create, "non_existing_module"), @create_attrs)
+      assert json_response(conn, 404)["errors"] == %{"detail" => "Not Found"}
+    end
+
+    test "error when creating already existing function", %{conn: conn} do
+      module = module_fixture()
+      conn = post(conn, Routes.function_path(conn, :create, module.name), @create_attrs)
+      assert json_response(conn, 201)["data"] == %{"name" => "some_name"}
+
+      conn = post(conn, Routes.function_path(conn, :create, module.name), @create_attrs)
+      assert json_response(conn, 409)["errors"] == %{"detail" => "Conflict"}
+    end
   end
 
   describe "update function" do


### PR DESCRIPTION
fixes #168

When creating a function that already exists we now return error code 409 (conflict).