### PR TITLE
Fix 404 when list functions request on non-existent module

### DIFF
--- a/apps/core/lib/core_web/controllers/module_controller.ex
+++ b/apps/core/lib/core_web/controllers/module_controller.ex
@@ -36,8 +36,10 @@ defmodule CoreWeb.ModuleController do
   end
 
   def show_functions(conn, %{"module_name" => name}) do
-    functions = Modules.get_functions_in_module(name)
-    render(conn, "show_functions.json", %{module_name: name, functions: functions})
+    with {:ok, %Module{}} <- Modules.get_module_by_name(name) do
+      functions = Modules.get_functions_in_module(name)
+      render(conn, "show_functions.json", %{module_name: name, functions: functions})
+    end
   end
 
   def update(conn, %{"module_name" => name, "module" => module_params}) do

--- a/apps/core/test/core_web/integration/controllers/module_controller_test.exs
+++ b/apps/core/test/core_web/integration/controllers/module_controller_test.exs
@@ -57,6 +57,11 @@ defmodule CoreWeb.ModuleControllerTest do
       assert json_response(conn, 200)["data"] ==
                %{"functions" => [%{"name" => "some_name"}], "name" => module.name}
     end
+
+    test "show_functions: list request on non-existend module fails", %{conn: conn} do
+      conn = get(conn, Routes.module_path(conn, :show_functions, "non_existent_module"))
+      assert json_response(conn, 404)
+    end
   end
 
   describe "create module" do


### PR DESCRIPTION
This PR fixes #176 

It adds a check on the module requested and a test for this case.