### PR TITLE
Add APP parsing and scheduling policies

### DIFF
--- a/apps/core/lib/core/adapters/telemetry/metrics.ex
+++ b/apps/core/lib/core/adapters/telemetry/metrics.ex
@@ -20,18 +20,15 @@ defmodule Core.Adapters.Telemetry.Metrics do
 
   alias Core.Adapters.Telemetry.MetricsServer
 
-  @type metrics :: %{
-          cpu: number(),
-          load_avg: %{l1: number(), l5: number(), l15: number()},
-          memory: %{free: number(), available: number(), total: number()}
-        }
-
   @impl true
-  @spec resources(any) :: {:ok, metrics} | {:error, :not_found}
+  @spec resources(any) :: {:ok, Data.Worker.Metrics.t()} | {:error, :not_found}
   def resources(worker) do
-    worker
-    |> retrieve_metrics
-    |> extract_resources
+    with {:ok, res} <-
+           worker
+           |> retrieve_metrics
+           |> extract_resources do
+      {:ok, struct(Data.Worker.Metrics, res)}
+    end
   end
 
   defp retrieve_metrics(worker), do: MetricsServer.get(worker)

--- a/apps/core/lib/core/adapters/telemetry/test.ex
+++ b/apps/core/lib/core/adapters/telemetry/test.ex
@@ -19,7 +19,7 @@ defmodule Core.Adapters.Telemetry.Test do
   @impl true
   def resources(_worker) do
     {:ok,
-     %{
+     %Data.Worker.Metrics{
        cpu: 1,
        load_avg: %{l1: 1, l5: 5, l15: 15},
        memory: %{free: 20, available: 10, total: 50}

--- a/apps/core/lib/core/domain/invoker.ex
+++ b/apps/core/lib/core/domain/invoker.ex
@@ -77,11 +77,12 @@ defmodule Core.Domain.Invoker do
 
     case Functions.get_code_by_name_in_mod!(ivk.function, ivk.module) do
       [f] ->
-        func = %FunctionStruct{
-          name: ivk.function,
-          module: ivk.module,
-          code: f.code
-        }
+        func =
+          struct(FunctionStruct, %{
+            name: ivk.function,
+            module: ivk.module,
+            code: f.code
+          })
 
         Commands.send_invoke_with_code(worker, func, ivk.args)
 

--- a/apps/core/lib/core/domain/policies/app.ex
+++ b/apps/core/lib/core/domain/policies/app.ex
@@ -24,7 +24,7 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.APP do
           | {:error, :no_matching_tag}
           | {:error, :no_function_metadata}
 
-  @spec select(Data.Configurations.APP.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
+  @spec select(APP.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
           {:ok, Data.Worker.t()} | {:error, :no_matching_tag} | select_errors()
   def select(
         %APP{tags: tags} = _configuration,
@@ -122,10 +122,14 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.APP do
         wrk |> Enum.random()
 
       {[_ | _] = wrk, :platform} ->
-        wrk
-        |> Enum.max_by(fn %Data.Worker{resources: %{memory: %{available: available}}} ->
-          available
-        end)
+        {:ok, selected} =
+          Core.Domain.Policies.SchedulingPolicy.select(
+            %Data.Configurations.Empty{},
+            wrk,
+            struct(Data.FunctionStruct, %{name: nil, module: nil})
+          )
+
+        selected
     end
   end
 

--- a/apps/core/lib/core/domain/policies/app.ex
+++ b/apps/core/lib/core/domain/policies/app.ex
@@ -24,7 +24,7 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.APP do
           | {:error, :no_matching_tag}
           | {:error, :no_function_metadata}
 
-  @spec select(Data.Configurations.APP.t(), [Data.Workers.t()], Data.FunctionStruct.t()) ::
+  @spec select(Data.Configurations.APP.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
           {:ok, Data.Worker.t()} | {:error, :no_matching_tag} | select_errors()
   def select(
         %APP{tags: tags} = _configuration,
@@ -65,6 +65,18 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.APP do
 
   def select(_, _, _) do
     {:error, :invalid_input}
+  end
+
+  defp schedule(
+         [
+           %Block{
+             workers: :*
+           } = block
+           | rest
+         ],
+         workers
+       ) do
+    schedule([block |> Map.put(:workers, workers) | rest], workers)
   end
 
   defp schedule(

--- a/apps/core/lib/core/domain/policies/app.ex
+++ b/apps/core/lib/core/domain/policies/app.ex
@@ -1,0 +1,121 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.APP do
+  alias Data.Configurations.APP
+  alias Data.Configurations.APP.Block
+  alias Data.Configurations.APP.Tag
+
+  @type select_errors ::
+          {:error, :no_workers}
+          | {:error, :no_valid_workers}
+          | {:error, :invalid_input}
+          | {:error, :no_matching_tag}
+          | {:error, :no_function_metadata}
+
+  @spec select(Data.Configurations.APP.t(), [Data.Workers.t()], Data.FunctionStruct.t()) ::
+          {:ok, Data.Worker.t()} | {:error, :no_matching_tag} | select_errors()
+  def select(
+        %APP{tags: tags} = _configuration,
+        [_ | _] = workers,
+        %Data.FunctionStruct{metadata: %{tag: tag_name, capacity: _function_capacity}}
+      ) do
+    default = tags |> Map.get("default")
+    tag = tags |> Map.get(tag_name, default)
+
+    with %Tag{blocks: [_ | _] = blocks, followup: followup} <- tag do
+      case {schedule(blocks, workers), followup, default} do
+        {nil, :fail, _} ->
+          {:error, :no_valid_workers}
+
+        {nil, :default, nil} ->
+          {:error, :no_valid_workers}
+
+        {nil, :default, %Tag{blocks: [_ | _] = default_blocks}} ->
+          schedule(default_blocks, workers)
+
+        {%Data.Worker{} = wrk, _, _} ->
+          {:ok, wrk}
+      end
+    else
+      nil -> {:error, :no_matching_tag}
+    end
+  end
+
+  def select(_, [], _) do
+    {:error, :no_workers}
+  end
+
+  def select(%APP{tags: _}, _, %Data.FunctionStruct{}) do
+    {:error, :no_function_metadata}
+  end
+
+  def select(_, _, _) do
+    {:error, :invalid_input}
+  end
+
+  defp schedule(
+         [
+           %Block{
+             workers: block_workers,
+             strategy: strategy,
+             invalidate: %{
+               capacity_used: invalidate_capacity,
+               max_concurrent_invocations: invalidate_invocations
+             }
+           }
+           | rest
+         ],
+         workers
+       ) do
+    filtered_workers =
+      block_workers
+      |> Enum.with_index(fn w, i -> {i, w} end)
+      |> MapSet.new()
+      |> MapSet.intersection(MapSet.new(workers))
+      |> MapSet.to_list()
+      |> Enum.map(fn {_, w} -> w end)
+      |> Enum.filter(fn %Data.Worker{concurrent_functions: c} ->
+        invalidate_invocations == :infinity or c < invalidate_invocations
+      end)
+      |> Enum.filter(fn %Data.Worker{
+                          resources: %Data.Worker.Metrics{
+                            memory: %{available: available, total: total}
+                          }
+                        } ->
+        (total - available) / total * 100 < invalidate_capacity
+      end)
+
+    case {filtered_workers, strategy} do
+      {[], _} ->
+        schedule(rest, workers)
+
+      {[h | _], :"best-first"} ->
+        h
+
+      {[_ | _] = wrk, :random} ->
+        wrk |> Enum.random()
+
+      {[_ | _] = wrk, :platform} ->
+        wrk
+        |> Enum.max_by(fn %Data.Worker{resources: %{memory: %{available: available}}} ->
+          available
+        end)
+    end
+  end
+
+  defp schedule([], _) do
+    nil
+  end
+end

--- a/apps/core/lib/core/domain/policies/default.ex
+++ b/apps/core/lib/core/domain/policies/default.ex
@@ -1,0 +1,33 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.Empty do
+  alias Data.Configurations.Empty
+
+  @spec select(Empty.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
+          {:ok, Data.Worker.t()} | {:error, :no_workers}
+  def select(
+        %Empty{},
+        [_ | _] = workers,
+        _
+      ) do
+    case workers
+         |> Enum.max_by(fn %Data.Worker{resources: %{memory: %{available: available}}} ->
+           available
+         end) do
+      nil -> {:error, :no_workers}
+      %Data.Worker{} = wrk -> {:ok, wrk}
+    end
+  end
+end

--- a/apps/core/lib/core/domain/policies/parsers/app.ex
+++ b/apps/core/lib/core/domain/policies/parsers/app.ex
@@ -1,0 +1,107 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Policies.Parsers.APP do
+  @spec parse_block(%{String.t() => any}) :: Data.Configurations.APP.Block.t()
+  def parse_block(%{"workers" => _, "strategy" => strategy} = block)
+      when strategy in ["random", "best-first", "platform"] do
+    block_with_atom_keys =
+      for {k, v} <- block, into: %{} do
+        {String.to_existing_atom(k), v}
+      end
+
+    {antiaffinity, affinity} =
+      block
+      |> Map.get("affinity", [])
+      |> Enum.split_with(fn t -> t |> String.starts_with?("!") end)
+
+    capacity_used = block |> Map.get("invalidate", %{}) |> Map.get("capacity_used", :infinity)
+
+    max_concurrent_invocations =
+      block |> Map.get("invalidate", %{}) |> Map.get("max_concurrent_invocations", :infinity)
+
+    struct(
+      Data.Configurations.APP.Block,
+      block_with_atom_keys
+      |> Map.put(:affinity, %{
+        affinity: affinity,
+        antiffinity: antiaffinity |> Enum.map(fn "!" <> s -> s end)
+      })
+      |> Map.put(:invalidate, %{
+        capacity_used: capacity_used,
+        max_concurrent_invocations: max_concurrent_invocations
+      })
+      |> Map.put(:strategy, strategy |> String.to_existing_atom())
+    )
+  end
+
+  def parse_block(%{"workers" => _} = block) do
+    parse_block(block |> Map.put("strategy", "best-first"))
+  end
+
+  @spec parse_tag([{String.t(), any}]) ::
+          {String.t(),
+           {:error, :no_blocks | :unknown_construct | :unknown_followup}
+           | {:ok, Data.Configurations.APP.Tag.t()}}
+  def parse_tag([{tag_name, [_ | _] = blocks}, {"followup", followup}])
+      when followup in ["default", "fail"] do
+    {tag_name,
+     {:ok,
+      %Data.Configurations.APP.Tag{
+        blocks: blocks |> Enum.map(&parse_block/1),
+        followup: String.to_existing_atom(followup)
+      }}}
+  end
+
+  def parse_tag([{_tag_name, _blocks = [_ | _]} = tag]) do
+    parse_tag([tag, {"followup", "fail"}])
+  end
+
+  def parse_tag([{tag_name, _blocks = [_ | _]}, {"followup", _}]) do
+    {tag_name, {:error, :unknown_followup}}
+  end
+
+  def parse_tag([{tag_name, []} | _]) do
+    {tag_name, {:error, :no_blocks}}
+  end
+
+  def parse_tag([{tag_name, _} | _]) do
+    {tag_name, {:error, :unknown_construct}}
+  end
+
+  @spec parse([map()]) :: Data.Configurations.APP.t() | %{String.t() => {:error, any}}
+  def parse_script([_ | _] = yaml) do
+    {parsed, errors} =
+      yaml
+      |> Enum.map(fn tag -> tag |> Map.to_list() |> parse_tag end)
+      |> Enum.split_with(fn {_, out} ->
+        case out do
+          {:ok, _} -> true
+          {:error, _} -> false
+        end
+      end)
+
+    case errors do
+      [] -> %Data.Configurations.APP{tags: parsed |> Enum.into(%{})}
+      [_ | _] -> errors |> Enum.into(%{})
+    end
+  end
+
+  @spec parse(String.t()) :: Data.Configurations.APP.t() | %{String.t() => {:error, any}}
+  def parse(content) do
+    with {:ok, yaml} <- YamlElixir.read_from_string(content) do
+      yaml |> parse_script()
+    end
+  end
+end

--- a/apps/core/lib/core/domain/policies/parsers/app.ex
+++ b/apps/core/lib/core/domain/policies/parsers/app.ex
@@ -13,55 +13,79 @@
 # limitations under the License.
 
 defmodule Core.Domain.Policies.Parsers.APP do
-  @spec parse_block(%{String.t() => any}) :: Data.Configurations.APP.Block.t()
-  def parse_block(%{"workers" => _, "strategy" => strategy} = block)
-      when strategy in ["random", "best-first", "platform"] do
-    block_with_atom_keys =
-      for {k, v} <- block, into: %{} do
-        {String.to_existing_atom(k), v}
-      end
+  @on_load :load_atoms
 
-    {antiaffinity, affinity} =
-      block
-      |> Map.get("affinity", [])
-      |> Enum.split_with(fn t -> t |> String.starts_with?("!") end)
+  defp load_atoms do
+    [Data.Configurations.APP, Data.Configurations.APP.Block, Data.Configurations.APP.Tag]
+    |> Enum.each(&Code.ensure_loaded?/1)
 
-    capacity_used = block |> Map.get("invalidate", %{}) |> Map.get("capacity_used", :infinity)
-
-    max_concurrent_invocations =
-      block |> Map.get("invalidate", %{}) |> Map.get("max_concurrent_invocations", :infinity)
-
-    struct(
-      Data.Configurations.APP.Block,
-      block_with_atom_keys
-      |> Map.put(:affinity, %{
-        affinity: affinity,
-        antiffinity: antiaffinity |> Enum.map(fn "!" <> s -> s end)
-      })
-      |> Map.put(:invalidate, %{
-        capacity_used: capacity_used,
-        max_concurrent_invocations: max_concurrent_invocations
-      })
-      |> Map.put(:strategy, strategy |> String.to_existing_atom())
-    )
+    :ok
   end
 
-  def parse_block(%{"workers" => _} = block) do
-    parse_block(block |> Map.put("strategy", "best-first"))
+  @spec parse(String.t()) ::
+          {:ok, Data.Configurations.APP.t()} | {:error, %{String.t() => {:error, any}}}
+  def parse(content) do
+    with {:ok, yaml} <- YamlElixir.read_from_string(content) do
+      yaml |> parse_script()
+    end
+  end
+
+  @spec parse_script([map()]) ::
+          {:ok, Data.Configurations.APP.t()} | {:error, %{String.t() => {:error, any}}}
+  def parse_script([_ | _] = yaml) do
+    {parsed, errors} =
+      yaml
+      |> Enum.map(fn tag -> tag |> Map.to_list() |> parse_tag end)
+      |> Enum.split_with(&match?({_, {:ok, _}}, &1))
+
+    case errors do
+      [] ->
+        {:ok,
+         %Data.Configurations.APP{
+           tags:
+             parsed
+             |> Enum.map(fn {tag_name, {:ok, tag}} -> {tag_name, tag} end)
+             |> Enum.into(%{})
+         }}
+
+      [_ | _] ->
+        {:error, errors |> Enum.into(%{})}
+    end
+  end
+
+  def parse_script(_) do
+    {:error, :unknown_construct}
   end
 
   @spec parse_tag([{String.t(), any}]) ::
           {String.t(),
-           {:error, :no_blocks | :unknown_construct | :unknown_followup}
+           {:error, :no_blocks | :unknown_construct | :unknown_followup | [{:error, any}]}
            | {:ok, Data.Configurations.APP.Tag.t()}}
+  def parse_tag([{"followup", _} = followup, {_, _} = tag]) do
+    parse_tag([tag, followup])
+  end
+
   def parse_tag([{tag_name, [_ | _] = blocks}, {"followup", followup}])
       when followup in ["default", "fail"] do
-    {tag_name,
-     {:ok,
-      %Data.Configurations.APP.Tag{
-        blocks: blocks |> Enum.map(&parse_block/1),
-        followup: String.to_existing_atom(followup)
-      }}}
+    {parsed, errors} =
+      blocks |> Enum.map(&parse_block/1) |> Enum.split_with(&match?({:ok, _}, &1))
+
+    tag_content =
+      case errors do
+        [] ->
+          {:ok,
+           %Data.Configurations.APP.Tag{
+             blocks:
+               parsed
+               |> Enum.map(fn {:ok, block} -> block end),
+             followup: String.to_existing_atom(followup)
+           }}
+
+        [_ | _] ->
+          {:error, errors}
+      end
+
+    {tag_name, tag_content}
   end
 
   def parse_tag([{_tag_name, _blocks = [_ | _]} = tag]) do
@@ -76,27 +100,66 @@ defmodule Core.Domain.Policies.Parsers.APP do
     {tag_name, {:error, :no_blocks}}
   end
 
+  def parse_tag([{tag_name, nil} | _]) do
+    {tag_name, {:error, :no_blocks}}
+  end
+
   def parse_tag([{tag_name, _} | _]) do
     {tag_name, {:error, :unknown_construct}}
   end
 
-  @spec parse([map()]) :: Data.Configurations.APP.t() | %{String.t() => {:error, any}}
-  def parse_script([_ | _] = yaml) do
-    {parsed, errors} =
-      yaml
-      |> Enum.map(fn tag -> tag |> Map.to_list() |> parse_tag end)
-      |> Enum.split_with(&match?({:ok, _}, &1))
+  @spec parse_block(%{String.t() => any}) ::
+          {:ok, Data.Configurations.APP.Block.t()} | {:error, :no_block_workers}
+  def parse_block(%{"workers" => wrk, "strategy" => strategy} = block)
+      when strategy in ["random", "best-first", "platform"] and (is_list(wrk) or is_binary(wrk)) do
+    block_with_atom_keys =
+      for {k, v} <- block, into: %{} do
+        {String.to_existing_atom(k), v}
+      end
 
-    case errors do
-      [] -> %Data.Configurations.APP{tags: parsed |> Enum.into(%{})}
-      [_ | _] -> errors |> Enum.into(%{})
-    end
+    {antiaffinity, affinity} =
+      block
+      |> Map.get("affinity", [])
+      |> Enum.split_with(fn t -> t |> String.starts_with?("!") end)
+
+    capacity_used =
+      block
+      |> Map.get("invalidate", %{})
+      |> Map.get("capacity_used", :infinity)
+      |> then(fn x ->
+        if x != :infinity do
+          {n, _} = Integer.parse(x)
+          n
+        else
+          x
+        end
+      end)
+
+    max_concurrent_invocations =
+      block |> Map.get("invalidate", %{}) |> Map.get("max_concurrent_invocations", :infinity)
+
+    {:ok,
+     struct(
+       Data.Configurations.APP.Block,
+       block_with_atom_keys
+       |> Map.put(:affinity, %{
+         affinity: affinity,
+         antiaffinity: antiaffinity |> Enum.map(fn "!" <> s -> s end)
+       })
+       |> Map.put(:invalidate, %{
+         capacity_used: capacity_used,
+         max_concurrent_invocations: max_concurrent_invocations
+       })
+       |> Map.put(:strategy, strategy |> String.to_existing_atom())
+     )}
   end
 
-  @spec parse(String.t()) :: Data.Configurations.APP.t() | %{String.t() => {:error, any}}
-  def parse(content) do
-    with {:ok, yaml} <- YamlElixir.read_from_string(content) do
-      yaml |> parse_script()
-    end
+  def parse_block(%{"workers" => wrk} = block)
+      when is_list(wrk) or is_binary(wrk) do
+    parse_block(block |> Map.put("strategy", "best-first"))
+  end
+
+  def parse_block(_) do
+    {:error, :no_block_workers}
   end
 end

--- a/apps/core/lib/core/domain/policies/parsers/app.ex
+++ b/apps/core/lib/core/domain/policies/parsers/app.ex
@@ -85,12 +85,7 @@ defmodule Core.Domain.Policies.Parsers.APP do
     {parsed, errors} =
       yaml
       |> Enum.map(fn tag -> tag |> Map.to_list() |> parse_tag end)
-      |> Enum.split_with(fn {_, out} ->
-        case out do
-          {:ok, _} -> true
-          {:error, _} -> false
-        end
-      end)
+      |> Enum.split_with(&match?({:ok, _}, &1))
 
     case errors do
       [] -> %Data.Configurations.APP{tags: parsed |> Enum.into(%{})}

--- a/apps/core/lib/core/domain/policies/scheduling_policy.ex
+++ b/apps/core/lib/core/domain/policies/scheduling_policy.ex
@@ -1,0 +1,26 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defprotocol Core.Domain.Policies.SchedulingPolicy do
+  @moduledoc """
+    Protocol to define scheduling policies.
+    Each policy is parameterized on the type of its configuration.
+  """
+
+  @doc """
+    Should select a worker from a list of workers, given a specific configuration.
+  """
+  @spec select(t, [Data.Worker.t()]) :: {:ok, Data.Worker.t()} | {:error, any}
+  def select(configuration, workers)
+end

--- a/apps/core/lib/core/domain/ports/telemetry/metrics.ex
+++ b/apps/core/lib/core/domain/ports/telemetry/metrics.ex
@@ -20,11 +20,11 @@ defmodule Core.Domain.Ports.Telemetry.Metrics do
   @type worker :: atom()
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
-  @callback resources(worker) :: {:ok, Data.Worker.Metrics} | {:error, :not_found}
+  @callback resources(worker) :: {:ok, Data.Worker.Metrics.t()} | {:error, :not_found}
 
   @doc """
   Function to obtain resource information on a specific worker.
   """
-  @spec resources(worker) :: {:ok, Data.Worker.Metrics} | {:error, :not_found}
+  @spec resources(worker) :: {:ok, Data.Worker.Metrics.t()} | {:error, :not_found}
   defdelegate resources(worker), to: @adapter
 end

--- a/apps/core/mix.exs
+++ b/apps/core/mix.exs
@@ -67,6 +67,7 @@ defmodule Core.MixProject do
       {:prom_ex, git: "https://github.com/akoutmos/prom_ex.git"},
       {:emqtt, github: "emqx/emqtt", tag: "1.6.1", system_env: [{"BUILD_WITHOUT_QUIC", "1"}]},
       {:ecto_psql_extras, "~> 0.7"},
+      {:yaml_elixir, "~> 2.9.0"},
       # dev deps
       {:mox, "~> 1.0", only: :test}
     ]

--- a/apps/core/test/core/unit/policies/app_policy_test.exs
+++ b/apps/core/test/core/unit/policies/app_policy_test.exs
@@ -286,7 +286,8 @@ defmodule Core.Unit.Policies.AppPolicyTest do
 
     test "select should return the same result as the default scheduling when the strategy is :platform",
          %{impl: app_impl, workers: workers, function: function, script: script} do
-      # regardless of the default scheduling implementation, the APP scheduler must use that policy when the "platform" strategy is given
+      # regardless of the default scheduling implementation,
+      # the APP scheduler must use that policy when the "platform" strategy is given
       default_impl = SchedulingPolicy.impl_for(%Data.Configurations.Empty{})
       [main_block | _] = Map.get(script.tags, "test-tag") |> Map.get(:blocks)
 
@@ -434,7 +435,8 @@ defmodule Core.Unit.Policies.AppPolicyTest do
         tags: script.tags |> Map.put("test-tag", %Tag{blocks: [additional_block]})
       }
 
-      # first check the unmodified script on the valid workers is actually working as intended (not part of the test, but nice to have in case it breaks)
+      # first check the unmodified script on the valid workers is actually working as intended
+      # (not part of the test, but nice to have in case it breaks)
       assert app_impl.select(script, workers, function) == {:ok, wrk1}
 
       # the result should be the same, whether wrk1 and wrk2 are invalid or not when using one_block_script

--- a/apps/core/test/core/unit/policies/app_policy_test.exs
+++ b/apps/core/test/core/unit/policies/app_policy_test.exs
@@ -1,0 +1,29 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.Policies.AppPolicyTest do
+end

--- a/apps/core/test/core/unit/policies/app_policy_test.exs
+++ b/apps/core/test/core/unit/policies/app_policy_test.exs
@@ -26,4 +26,485 @@
 # limitations under the License.
 
 defmodule Core.Unit.Policies.AppPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Domain.Policies.SchedulingPolicy
+  alias Data.Configurations.APP
+  alias Data.Configurations.APP.Block
+  alias Data.Configurations.APP.Tag
+  alias Data.FunctionMetadata
+  alias Data.FunctionStruct
+  alias Data.Worker
+  alias Data.Worker.Metrics
+
+  setup_all do
+    implementation = SchedulingPolicy.impl_for(%APP{})
+    %{impl: implementation}
+  end
+
+  describe "protocol" do
+    test "the module should be a valid implementation of the SchedulingPolicy protocol for the Data.Configurations.APP type",
+         %{impl: app_impl} do
+      assert Protocol.assert_impl!(SchedulingPolicy, APP) == :ok
+      assert app_impl != nil
+    end
+  end
+
+  describe "is_valid?" do
+    test "is_valid? should return true when invalidate options are :infinity and the worker can host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 100,
+        resources: %Metrics{
+          memory: %{available: 128, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = :infinity
+      invalidate_invocations = :infinity
+
+      assert app_impl.is_valid?(
+               wrk,
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == true
+    end
+
+    test "is_valid? should return true when invalidate options are satisfied and the worker can host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 256, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = 50
+      invalidate_invocations = 1
+
+      assert app_impl.is_valid?(
+               wrk,
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == true
+    end
+
+    test "is_valid? should return false when invalidate options are :infinity and the worker can't host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 127, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = :infinity
+      invalidate_invocations = :infinity
+
+      assert app_impl.is_valid?(
+               wrk,
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == false
+    end
+
+    test "is_valid? should return false when invalidate options are not satisfied or the worker can't host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 128, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = 49
+      invalidate_invocations = 1
+
+      assert app_impl.is_valid?(
+               wrk,
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == false
+
+      assert app_impl.is_valid?(
+               wrk |> Map.put(:concurrent_functions, 1),
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == false
+
+      assert app_impl.is_valid?(
+               wrk |> Map.put(:resources, %Metrics{memory: %{available: 127, total: 256}}),
+               function,
+               invalidate_capacity,
+               invalidate_invocations
+             ) == false
+    end
+  end
+
+  describe "select" do
+    setup do
+      wrk = %Worker{
+        name: "worker@localhost",
+        long_name: "worker1",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 256, total: 256}
+        }
+      }
+
+      workers = [
+        wrk,
+        wrk |> Map.put(:long_name, "worker2"),
+        wrk |> Map.put(:long_name, "worker3")
+      ]
+
+      script = %APP{
+        tags: %{
+          "test-tag" => %Tag{
+            blocks: [
+              %Block{
+                affinity: %{affinity: [], antiaffinity: []},
+                workers: ["worker1", "worker2"],
+                strategy: :"best-first",
+                invalidate: %{
+                  capacity_used: :infinity,
+                  max_concurrent_invocations: :infinity
+                }
+              }
+            ],
+            followup: :default
+          },
+          "default" => %Tag{
+            blocks: [
+              %Block{
+                affinity: %{affinity: [], antiaffinity: []},
+                workers: ["worker3"],
+                strategy: :"best-first",
+                invalidate: %{
+                  capacity_used: :infinity,
+                  max_concurrent_invocations: :infinity
+                }
+              }
+            ],
+            followup: :fail
+          }
+        }
+      }
+
+      script_no_default = %APP{
+        tags: script.tags |> Map.put("default", nil)
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128,
+          tag: "test-tag"
+        }
+      }
+
+      %{
+        workers: workers,
+        script: script,
+        script_no_default: script_no_default,
+        function: function
+      }
+    end
+
+    test "select should return the first valid worker in the script when the strategy is :best-first",
+         %{
+           impl: app_impl,
+           workers: [wrk, wrk2, wrk3] = workers,
+           script: script,
+           function: function
+         } do
+      assert app_impl.select(script, workers, function) == {:ok, wrk}
+      assert app_impl.is_valid?(wrk, function, :infinity, :infinity)
+
+      # invalidating the first worker causes select() to choose "worker2"
+      workers_invalid_first = [
+        wrk
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        }),
+        wrk2,
+        wrk3
+      ]
+
+      assert app_impl.select(script, workers_invalid_first, function) == {:ok, wrk2}
+      assert app_impl.is_valid?(wrk2, function, :infinity, :infinity)
+    end
+
+    test "select should return a valid worker in the script when the strategy is :random",
+         %{impl: app_impl, workers: workers, script: script, function: function} do
+      {:ok, wrk} = app_impl.select(script, workers, function)
+      assert app_impl.is_valid?(wrk, function, :infinity, :infinity)
+      assert Enum.member?(workers, wrk) == true
+    end
+
+    test "select should return the same result as the default scheduling when the strategy is :platform",
+         %{impl: app_impl, workers: workers, function: function, script: script} do
+      # regardless of the default scheduling implementation, the APP scheduler must use that policy when the "platform" strategy is given
+      default_impl = SchedulingPolicy.impl_for(%Data.Configurations.Empty{})
+      [main_block | _] = Map.get(script.tags, "test-tag") |> Map.get(:blocks)
+
+      platform_script = %APP{
+        tags:
+          script.tags
+          |> Map.put("test-tag", %Tag{blocks: [main_block |> Map.put(:strategy, :platform)]})
+      }
+
+      {:ok, wrk} = app_impl.select(platform_script, workers, function)
+      {:ok, wrk_default} = default_impl.select(%Data.Configurations.Empty{}, workers, function)
+
+      assert app_impl.is_valid?(wrk, function, :infinity, :infinity)
+      assert Enum.member?(workers, wrk) == true
+      assert wrk_default == wrk
+    end
+
+    test "select should use the default tag when the function's tag is not found in the script, but the default tag is defined",
+         %{impl: app_impl, workers: [_, _, wrk3] = workers, script: script} do
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          tag: "non-existent-tag",
+          capacity: 128
+        }
+      }
+
+      assert app_impl.select(script, workers, function) == {:ok, wrk3}
+
+      only_default_script = %APP{
+        tags: %{"default" => Map.get(script.tags, "default")}
+      }
+
+      assert app_impl.select(script, workers, function) ==
+               app_impl.select(only_default_script, workers, function)
+    end
+
+    test "select should use the default tag when no valid workers are found and followup is :default",
+         %{impl: app_impl, workers: [wrk1, wrk2, wrk3], script: script, function: function} do
+      wrk1 =
+        wrk1
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      wrk2 =
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      invalidate_workers = [wrk1, wrk2, wrk3]
+
+      assert app_impl.select(script, invalidate_workers, function) == {:ok, wrk3}
+
+      only_default_script = %APP{
+        tags: %{"default" => Map.get(script.tags, "default")}
+      }
+
+      assert app_impl.select(script, invalidate_workers, function) ==
+               app_impl.select(only_default_script, invalidate_workers, function)
+    end
+
+    test "select should pick from all existing workers when :workers is *",
+         %{impl: app_impl, workers: workers, script: script, function: function} do
+      [_wrk1, wrk2, wrk3] = workers
+      [main_block | _] = Map.get(script.tags, "test-tag") |> Map.get(:blocks)
+
+      star_workers_script = %APP{
+        tags:
+          script.tags |> Map.put("test-tag", %Tag{blocks: [main_block |> Map.put(:workers, "*")]})
+      }
+
+      list_workers_script = %APP{
+        tags:
+          script.tags
+          |> Map.put("test-tag", %Tag{
+            blocks: [
+              main_block |> Map.put(:workers, ["worker1", "worker2", "worker3"])
+            ]
+          })
+      }
+
+      # the "*" specification for workers selects all workers currently available as potential hosts for the function
+      assert app_impl.select(star_workers_script, workers, function) ==
+               app_impl.select(list_workers_script, workers, function)
+
+      list_workers_script = %APP{
+        tags:
+          script.tags
+          |> Map.put("test-tag", %Tag{
+            blocks: [
+              main_block |> Map.put(:workers, ["worker2", "worker3"])
+            ]
+          })
+      }
+
+      assert app_impl.select(star_workers_script, [wrk2, wrk3], function) ==
+               app_impl.select(list_workers_script, [wrk2, wrk3], function)
+
+      list_workers_script = %APP{
+        tags:
+          script.tags
+          |> Map.put("test-tag", %Tag{
+            blocks: [
+              main_block |> Map.put(:workers, ["worker3"])
+            ]
+          })
+      }
+
+      assert app_impl.select(star_workers_script, [wrk3], function) ==
+               app_impl.select(list_workers_script, [wrk3], function)
+    end
+
+    test "select should keep iterating over blocks when the first one has no valid workers",
+         %{
+           impl: app_impl,
+           workers: [wrk1, wrk2, wrk3] = workers,
+           script: script,
+           function: function
+         } do
+      wrk1_inv =
+        wrk1
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      wrk2_inv =
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      invalidate_workers = [wrk1_inv, wrk2_inv, wrk3]
+
+      [main_block | _] = Map.get(script.tags, "test-tag") |> Map.get(:blocks)
+      additional_block = main_block |> Map.put(:workers, ["worker3"])
+
+      two_block_script = %APP{
+        tags: script.tags |> Map.put("test-tag", %Tag{blocks: [main_block, additional_block]})
+      }
+
+      one_block_script = %APP{
+        tags: script.tags |> Map.put("test-tag", %Tag{blocks: [additional_block]})
+      }
+
+      # first check the unmodified script on the valid workers is actually working as intended (not part of the test, but nice to have in case it breaks)
+      assert app_impl.select(script, workers, function) == {:ok, wrk1}
+
+      # the result should be the same, whether wrk1 and wrk2 are invalid or not when using one_block_script
+      assert app_impl.select(two_block_script, invalidate_workers, function) == {:ok, wrk3}
+
+      assert app_impl.select(two_block_script, invalidate_workers, function) ==
+               app_impl.select(one_block_script, invalidate_workers, function)
+
+      assert app_impl.select(two_block_script, invalidate_workers, function) ==
+               app_impl.select(one_block_script, workers, function)
+    end
+
+    test "select should filter out workers that do not exist",
+         %{impl: app_impl, workers: [wrk1, _, _] = workers, script: script, function: function} do
+      [main_block | _] = Map.get(script.tags, "test-tag") |> Map.get(:blocks)
+
+      bad_wrk_block =
+        main_block |> Map.put(:workers, ["bad-wrk1", "bad-wrk2", "worker1", "worker2"])
+
+      bad_wrk_script = %APP{
+        tags: script.tags |> Map.put("test-tag", %Tag{blocks: [bad_wrk_block]})
+      }
+
+      assert app_impl.select(bad_wrk_script, workers, function) == {:ok, wrk1}
+
+      assert app_impl.select(bad_wrk_script, workers, function) ==
+               app_impl.select(script, workers, function)
+    end
+
+    test "select should return {:error, :no_workers} when given an empty worker list",
+         %{impl: app_impl, script: script, function: function} do
+      assert app_impl.select(script, [], function) == {:error, :no_workers}
+    end
+
+    test "select should return {:error, :no_valid_workers} when given a non-empty worker list, but finding no valid workers" do
+    end
+
+    test "select should return {:error, :no_matching_tag} when the function's tag is not found in the script and default tag is undefined",
+         %{impl: app_impl, workers: workers, script_no_default: script_no_default} do
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          tag: "non-existent-tag",
+          capacity: 128
+        }
+      }
+
+      assert app_impl.select(script_no_default, workers, function) == {:error, :no_matching_tag}
+    end
+
+    test "select should return {:error, :no_function_metadata} when given a function with no associated metadata",
+         %{impl: app_impl, workers: workers, script: script} do
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod"
+      }
+
+      assert app_impl.select(script, workers, function) ==
+               {:error, :no_function_metadata}
+    end
+
+    test "select should return {:error, :invalid_input} when given broken or incomplete data",
+         %{impl: app_impl, workers: workers, script: script, function: function} do
+      assert app_impl.select(%{}, workers, function) ==
+               {:error, :invalid_input}
+
+      assert app_impl.select(script, %{}, function) == {:error, :invalid_input}
+
+      assert app_impl.select(script, workers, %{}) == {:error, :invalid_input}
+    end
+  end
 end

--- a/apps/core/test/core/unit/policies/parsers/app_parser_test.exs
+++ b/apps/core/test/core/unit/policies/parsers/app_parser_test.exs
@@ -1,0 +1,62 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.Policies.Parsers.AppParserTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Domain.Policies.Parsers
+  alias Data.Configurations.APP
+  alias Data.Configurations.APP.Block
+  alias Data.Configurations.APP.Tag
+
+  import(Mox, only: [verify_on_exit!: 1])
+
+  setup :verify_on_exit!
+
+  describe "Parser" do
+    test "parse should return {:error, :no_blocks} if a tag without blocks is given" do
+      script = File.read!("test/support/fixtures/APP/no_blocks.yml")
+    end
+
+    test "parse should return {:error, :unknown_followup} if a tag includes a followup other than 'fail' or 'default'" do
+      script = File.read!("test/support/fixtures/APP/unknown_followup.yml")
+    end
+
+    test "parse should return {:error, :unknown_construct} if a tag defines something other than blocks and followup" do
+      script = File.read!("test/support/fixtures/APP/unknown_construct.yml")
+    end
+
+    test "parse should return a valid APP struct when given a correct script (invalidate.yml)" do
+      script = File.read!("test/support/fixtures/APP/invalidate.yml")
+    end
+
+    test "parse should return a valid APP struct when given a correct script (producer_consumer.yml)" do
+      script = File.read!("test/support/fixtures/APP/producer_consumer.yml")
+    end
+  end
+end

--- a/apps/core/test/support/fixtures/APP/invalidate.yml
+++ b/apps/core/test/support/fixtures/APP/invalidate.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - t:
   - workers:
     - w1

--- a/apps/core/test/support/fixtures/APP/invalidate.yml
+++ b/apps/core/test/support/fixtures/APP/invalidate.yml
@@ -1,0 +1,7 @@
+- t:
+  - workers:
+    - w1
+    - w2
+    invalidate:
+      capacity_used: 50%
+      max_concurrent_invocations: 3

--- a/apps/core/test/support/fixtures/APP/no_blocks.yml
+++ b/apps/core/test/support/fixtures/APP/no_blocks.yml
@@ -12,32 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- producer:
+- t:
   - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "consumer"
-      - "!heavy"
-
-- consumer:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "producer"
-      - "!heavy"
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "!heavy"
-
-- heavy:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
+    - w1
+    - w2
+    invalidate:
+      capacity_used: 50%
+      max_concurrent_invocations: 3
+- t2:
+  followup: fail

--- a/apps/core/test/support/fixtures/APP/no_workers.yml
+++ b/apps/core/test/support/fixtures/APP/no_workers.yml
@@ -12,32 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- producer:
+- t:
   - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "consumer"
-      - "!heavy"
-
-- consumer:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "producer"
-      - "!heavy"
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "!heavy"
-
-- heavy:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
+    invalidate:
+      capacity_used: 50%
+      max_concurrent_invocations: 3

--- a/apps/core/test/support/fixtures/APP/producer_consumer.yml
+++ b/apps/core/test/support/fixtures/APP/producer_consumer.yml
@@ -1,0 +1,29 @@
+- producer:
+  - workers:
+    - worker1
+    - worker2
+    strategy: random
+    affinity:
+      - "consumer"
+      - "!heavy"
+
+- consumer:
+  - workers:
+    - worker1
+    - worker2
+    strategy: random
+    affinity:
+      - "producer"
+      - "!heavy"
+  - workers:
+    - worker1
+    - worker2
+    strategy: random
+    affinity:
+      - "!heavy"
+
+- heavy:
+  - workers:
+    - worker1
+    - worker2
+    strategy: random

--- a/apps/core/test/support/fixtures/APP/unknown_construct.yml
+++ b/apps/core/test/support/fixtures/APP/unknown_construct.yml
@@ -12,32 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- producer:
+- t:
   - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "consumer"
-      - "!heavy"
-
-- consumer:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "producer"
-      - "!heavy"
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "!heavy"
-
-- heavy:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
+    - w1
+    - w2
+    invalidate:
+      capacity_used: 50%
+      max_concurrent_invocations: 3
+  followup: fail
+  construct: value

--- a/apps/core/test/support/fixtures/APP/unknown_followup.yml
+++ b/apps/core/test/support/fixtures/APP/unknown_followup.yml
@@ -19,4 +19,4 @@
     invalidate:
       capacity_used: 50%
       max_concurrent_invocations: 3
-    followup: wrong
+  followup: wrong

--- a/apps/core/test/support/fixtures/APP/unknown_followup.yml
+++ b/apps/core/test/support/fixtures/APP/unknown_followup.yml
@@ -12,32 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- producer:
+- t:
   - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "consumer"
-      - "!heavy"
-
-- consumer:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "producer"
-      - "!heavy"
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
-    affinity:
-      - "!heavy"
-
-- heavy:
-  - workers:
-    - worker1
-    - worker2
-    strategy: random
+    - w1
+    - w2
+    invalidate:
+      capacity_used: 50%
+      max_concurrent_invocations: 3
+    followup: wrong

--- a/apps/data/lib/configurations/app.ex
+++ b/apps/data/lib/configurations/app.ex
@@ -1,0 +1,54 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Data.Configurations.APP.Block do
+  @type t :: %__MODULE__{
+          strategy: :random | :"best-first" | :platform,
+          workers: String.t() | [String.t()],
+          invalidate: %{
+            capacity_used: number() | :infinity,
+            max_concurrent_invocations: number() | :infinity
+          },
+          affinity: %{
+            affnity: [String.t()],
+            antiaffinity: [String.t()]
+          }
+        }
+  defstruct [
+    :workers,
+    affinity: %{
+      affinity: [],
+      antiaffinity: []
+    },
+    strategy: :"best-first",
+    invalidate: %{capacity_used: :infinity, max_concurrent_invocations: :infinity}
+  ]
+end
+
+defmodule Data.Configurations.APP.Tag do
+  @type t :: %__MODULE__{
+          blocks: [APP.Block.t()],
+          followup: :default | :fail
+        }
+  defstruct [:blocks, followup: :fail]
+end
+
+defmodule Data.Configurations.APP do
+  @type t :: %__MODULE__{
+          tags: %{
+            String.t() => Data.Configurations.APP.Tag
+          }
+        }
+  defstruct [:tags]
+end

--- a/apps/data/lib/configurations/app.ex
+++ b/apps/data/lib/configurations/app.ex
@@ -13,6 +13,21 @@
 # limitations under the License.
 
 defmodule Data.Configurations.APP.Block do
+  @moduledoc """
+  Struct encoding a Block in an APP configuration script.
+  Generally used as content for %APP.Tag{}.
+
+  ## Fields
+  - workers: either a list of String or the single "*" String.
+             Encodes the desired workers when using this block in scheduling
+             ("*" meaning all available workers).
+  - strategy: either the :random, :"best-first" or :platform atom.
+              Encodes the strategy that will be used to select worker, when using this block in scheduling.
+  - invalidate: a map with :capacity_used and :max_concurrent_invocations keys, with values extracted from an APP script.
+                Encodes conditions used to determine whether a given worker is valid,
+                when using this block in scheduling.
+  - affinity: a map with :affinity and :antiaffinity keys. Currently unused.
+  """
   @type t :: %__MODULE__{
           strategy: :random | :"best-first" | :platform,
           workers: String.t() | [String.t()],
@@ -37,6 +52,14 @@ defmodule Data.Configurations.APP.Block do
 end
 
 defmodule Data.Configurations.APP.Tag do
+  @moduledoc """
+  Struct encoding a Tag in an APP configuration script.
+  Generally used as content for %APP{}.
+
+  ## Fields
+  - blocks: a list of APP.Block structs, each encoding a single block defined for the tag in the APP script.
+  - followup: either the :default or the :fail atom, extracted from the APP script.
+  """
   @type t :: %__MODULE__{
           blocks: [Data.Configurations.APP.Block.t()],
           followup: :default | :fail
@@ -45,6 +68,14 @@ defmodule Data.Configurations.APP.Tag do
 end
 
 defmodule Data.Configurations.APP do
+  @moduledoc """
+  Struct encoding an APP configuration script.
+  Generally produced by Core.Domain.Policies.Parsers.APP.parse/1.
+
+  ## Fields
+  - tags: map with String keys and APP.Tag values.
+          Associates the name of each tag with the struct encoding the tag.
+  """
   @type t :: %__MODULE__{
           tags: %{
             String.t() => Data.Configurations.APP.Tag

--- a/apps/data/lib/configurations/app.ex
+++ b/apps/data/lib/configurations/app.ex
@@ -38,7 +38,7 @@ end
 
 defmodule Data.Configurations.APP.Tag do
   @type t :: %__MODULE__{
-          blocks: [APP.Block.t()],
+          blocks: [Data.Configurations.APP.Block.t()],
           followup: :default | :fail
         }
   defstruct [:blocks, followup: :fail]

--- a/apps/data/lib/configurations/empty.ex
+++ b/apps/data/lib/configurations/empty.ex
@@ -1,0 +1,18 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Data.Configurations.Empty do
+  @type t :: %__MODULE__{}
+  defstruct []
+end

--- a/apps/data/lib/configurations/empty.ex
+++ b/apps/data/lib/configurations/empty.ex
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 defmodule Data.Configurations.Empty do
+  @moduledoc """
+  Represents the absence of a scheduling configuration.
+  Used in the default scheduling, as it does not require any configuration file.
+  """
   @type t :: %__MODULE__{}
   defstruct []
 end

--- a/apps/data/lib/function.ex
+++ b/apps/data/lib/function.ex
@@ -21,12 +21,14 @@ defmodule Data.FunctionStruct do
       - name: function name
       - module: function module
       - code: function code binary
+      - metadata: additional information about the function
   """
   @type t :: %__MODULE__{
           module: String.t(),
           name: String.t(),
-          code: binary()
+          code: binary(),
+          metadata: Data.FunctionMetadata.t()
         }
   @enforce_keys [:name, :module]
-  defstruct [:name, :module, :code]
+  defstruct [:name, :module, :code, :metadata]
 end

--- a/apps/data/lib/function_metadata.ex
+++ b/apps/data/lib/function_metadata.ex
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defprotocol Core.Domain.Policies.SchedulingPolicy do
-  @moduledoc """
-    Protocol to define scheduling policies.
-    Each policy is parameterized on the type of its configuration.
-  """
-
-  @doc """
-    Should select a worker from a list of workers, given a specific configuration.
-  """
-  @spec select(t, [Data.Worker.t()], Data.FunctionStruct.t()) ::
-          {:ok, Data.Worker.t()} | {:error, any}
-  def select(configuration, workers, function)
+defmodule Data.FunctionMetadata do
+  @type t :: %__MODULE__{
+          tag: String.t(),
+          capacity: integer()
+        }
+  defstruct [:tag, :capacity]
 end

--- a/apps/data/lib/function_metadata.ex
+++ b/apps/data/lib/function_metadata.ex
@@ -13,9 +13,16 @@
 # limitations under the License.
 
 defmodule Data.FunctionMetadata do
+  @moduledoc """
+  A struct that represents the metadata associated with a function.
+
+  ## Fields
+    - tag: a string containing the function's tag. Can be anything, generally used with custom scheduling policies or metrics.
+    - capacity: the amount of memory this function requires to be allocated on a worker
+  """
   @type t :: %__MODULE__{
           tag: String.t(),
           capacity: integer()
         }
-  defstruct [:tag, :capacity]
+  defstruct tag: nil, capacity: -1
 end

--- a/apps/data/lib/worker.ex
+++ b/apps/data/lib/worker.ex
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule Core.Domain.Ports.Telemetry.Metrics do
-  @moduledoc """
-  Port for requesting telemetry information about workers.
-  """
+defmodule Data.Worker.Metrics do
+  @type t :: %__MODULE__{
+          cpu: number(),
+          load_avg: %{l1: number(), l5: number(), l15: number()},
+          memory: %{free: number(), available: number(), total: number()}
+        }
+  defstruct [:cpu, :load_avg, :memory]
+end
 
-  @type worker :: atom()
-  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
-
-  @callback resources(worker) :: {:ok, Data.Worker.Metrics} | {:error, :not_found}
-
-  @doc """
-  Function to obtain resource information on a specific worker.
-  """
-  @spec resources(worker) :: {:ok, Data.Worker.Metrics} | {:error, :not_found}
-  defdelegate resources(worker), to: @adapter
+defmodule Data.Worker do
+  @type t :: %__MODULE__{
+          name: atom(),
+          resources: Data.Worker.Metrics,
+          tag: String.t()
+        }
+  @enforce_keys [:name]
+  defstruct [:name, :resources, :tag]
 end

--- a/apps/data/lib/worker.ex
+++ b/apps/data/lib/worker.ex
@@ -18,16 +18,18 @@ defmodule Data.Worker do
 
   ## Fields
     - name: name of BEAM instance hosting the Worker
+    - long_name: string representing a symbolic name for the worker; can be unrelated to the :name attribute
     - resources: metrics collected about the Worker
     - tag: tag of the Worker, used to group it with similar ones
     - concurrent_functions: number of functions currently running on the Worker
   """
   @type t :: %__MODULE__{
           name: atom(),
+          long_name: String.t(),
           resources: Data.Worker.Metrics,
           tag: String.t(),
           concurrent_functions: integer()
         }
   @enforce_keys [:name]
-  defstruct [:name, :resources, :tag, :concurrent_functions]
+  defstruct [:name, :long_name, :resources, :tag, :concurrent_functions]
 end

--- a/apps/data/lib/worker.ex
+++ b/apps/data/lib/worker.ex
@@ -26,7 +26,7 @@ defmodule Data.Worker do
   @type t :: %__MODULE__{
           name: atom(),
           long_name: String.t(),
-          resources: Data.Worker.Metrics,
+          resources: Data.Worker.Metrics.t(),
           tag: String.t(),
           concurrent_functions: integer()
         }

--- a/apps/data/lib/worker.ex
+++ b/apps/data/lib/worker.ex
@@ -12,21 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defmodule Data.Worker.Metrics do
-  @type t :: %__MODULE__{
-          cpu: number(),
-          load_avg: %{l1: number(), l5: number(), l15: number()},
-          memory: %{free: number(), available: number(), total: number()}
-        }
-  defstruct [:cpu, :load_avg, :memory]
-end
-
 defmodule Data.Worker do
+  @moduledoc """
+  Struct describing a Worker node.
+
+  ## Fields
+    - name: name of BEAM instance hosting the Worker
+    - resources: metrics collected about the Worker
+    - tag: tag of the Worker, used to group it with similar ones
+    - concurrent_functions: number of functions currently running on the Worker
+  """
   @type t :: %__MODULE__{
           name: atom(),
           resources: Data.Worker.Metrics,
-          tag: String.t()
+          tag: String.t(),
+          concurrent_functions: integer()
         }
   @enforce_keys [:name]
-  defstruct [:name, :resources, :tag]
+  defstruct [:name, :resources, :tag, :concurrent_functions]
 end

--- a/apps/data/lib/worker_metrics.ex
+++ b/apps/data/lib/worker_metrics.ex
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-defprotocol Core.Domain.Policies.SchedulingPolicy do
+defmodule Data.Worker.Metrics do
   @moduledoc """
-    Protocol to define scheduling policies.
-    Each policy is parameterized on the type of its configuration.
-  """
+  Struct describing metrics collected about a Worker.
 
-  @doc """
-    Should select a worker from a list of workers, given a specific configuration.
+  ## Fields
+    - cpu: percentage of cpu currently in use
+    - load_avg: load average over 1, 5 and 15 minutes
+    - memory: free, available and total RAM in the system
   """
-  @spec select(t, [Data.Worker.t()], Data.FunctionStruct.t()) ::
-          {:ok, Data.Worker.t()} | {:error, any}
-  def select(configuration, workers, function)
+  @type t :: %__MODULE__{
+          cpu: number(),
+          load_avg: %{l1: number(), l5: number(), l15: number()},
+          memory: %{free: number(), available: number(), total: number()}
+        }
+  defstruct [:cpu, :load_avg, :memory]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -61,4 +61,6 @@
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "wasmex": {:hex, :wasmex, "0.8.2", "5e781944b32105b1f606b04e99a1acb39d65ba8660ad5bc4ba233340842f8de5", [:mix], [{:rustler, "~> 0.26.0", [hex: :rustler, repo: "hexpm", optional: true]}, {:rustler_precompiled, "~> 0.5.5", [hex: :rustler_precompiled, repo: "hexpm", optional: false]}], "hexpm", "44a5c3452565d08453433f8d66fa19c46bc2f87ac9125fd24eb535677cf58313"},
+  "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.9.0", "9a256da867b37b8d2c1ffd5d9de373a4fda77a32a45b452f1708508ba7bbcb53", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "0cb0e7d4c56f5e99a6253ed1a670ed0e39c13fc45a6da054033928607ac08dfc"},
 }


### PR DESCRIPTION
This PR adds support for APP configuration files (https://giuseppedepalma.com/research/icsoc/).

Specifically:
- Adds a parser for the APP configuration language
- Adds a specific Protocol to define scheduling policies based on different configurations (currently only APP)
- Extends the current Scheduler to support the policies
- Implements the default scheduling policy using the new Protocol, to preserve the previous behaviour
- Extends the Data layer with types for APP structures and additional Worker metadata

**NOTE**: this PR *does not* add support for CRUD operations on APP files, nor for the collection of the necessary Worker metadata. At the time of writing, the plan is to add these features as part of future PRs to ease the review process.