### PR TITLE
add some crud ops for app scripts

### DIFF
--- a/core/lib/core/app_scripts.ex
+++ b/core/lib/core/app_scripts.ex
@@ -1,0 +1,119 @@
+defmodule Core.APPScripts do
+  @moduledoc """
+  The APPScripts context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Core.Repo
+
+  alias Core.APPScripts.APP
+
+  @doc """
+  Returns the list of app_scripts.
+
+  ## Examples
+
+      iex> list_app_scripts()
+      [%APP{}, ...]
+
+  """
+  def list_app_scripts do
+    Repo.all(APP)
+  end
+
+  @doc """
+  Gets a single app_script by name.
+
+  ## Examples
+
+      iex> get_app_script_by_name("some_name")
+      %APP{}
+
+      iex> get_app_script_by_name("non_existent_name")
+      nil
+  """
+  def get_app_script_by_name(name) do
+    Repo.get_by(APP, name: name)
+  end
+
+  @doc """
+  Gets a single app_script.
+
+  Raises `Ecto.NoResultsError` if the App script does not exist.
+
+  ## Examples
+
+      iex> get_app_script!(123)
+      %APP{}
+
+      iex> get_app_script!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_app_script!(id), do: Repo.get!(APP, id)
+
+  @doc """
+  Creates a app_script.
+
+  ## Examples
+
+      iex> create_app_script(%{field: value})
+      {:ok, %APP{}}
+
+      iex> create_app_script(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_app_script(attrs \\ %{}) do
+    %APP{}
+    |> APP.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a app_script.
+
+  ## Examples
+
+      iex> update_app_script(app_script, %{field: new_value})
+      {:ok, %APP{}}
+
+      iex> update_app_script(app_script, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_app_script(%APP{} = app_script, attrs) do
+    app_script
+    |> APP.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a app_script.
+
+  ## Examples
+
+      iex> delete_app_script(app_script)
+      {:ok, %APP{}}
+
+      iex> delete_app_script(app_script)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_app_script(%APP{} = app_script) do
+    Repo.delete(app_script)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking app_script changes.
+
+  ## Examples
+
+      iex> change_app_script(app_script)
+      %Ecto.Changeset{data: %APP{}}
+
+  """
+  def change_app_script(%APP{} = app_script, attrs \\ %{}) do
+    APP.changeset(app_script, attrs)
+  end
+end

--- a/core/lib/core/app_scripts.ex
+++ b/core/lib/core/app_scripts.ex
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule Core.APPScripts do
   @moduledoc """
   The APPScripts context.

--- a/core/lib/core/app_scripts/app_script.ex
+++ b/core/lib/core/app_scripts/app_script.ex
@@ -1,3 +1,17 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 defmodule Core.APPScripts.APP do
   @moduledoc """
   The APP script schema.

--- a/core/lib/core/app_scripts/app_script.ex
+++ b/core/lib/core/app_scripts/app_script.ex
@@ -1,4 +1,7 @@
 defmodule Core.APPScripts.APP do
+  @moduledoc """
+  The APP script schema.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/core/lib/core/app_scripts/app_script.ex
+++ b/core/lib/core/app_scripts/app_script.ex
@@ -1,0 +1,19 @@
+defmodule Core.APPScripts.APP do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "app_scripts" do
+    field(:name, :string)
+    field(:script, :string)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(app_script, attrs) do
+    app_script
+    |> cast(attrs, [:name, :script])
+    |> validate_required([:name, :script])
+    |> unique_constraint(:name)
+  end
+end

--- a/core/lib/core_web/controllers/app_script_controller.ex
+++ b/core/lib/core_web/controllers/app_script_controller.ex
@@ -1,0 +1,42 @@
+defmodule CoreWeb.APPScriptController do
+  use CoreWeb, :controller
+
+  alias Core.APPScripts
+  alias Core.APPScripts.APP
+
+  action_fallback(CoreWeb.FallbackController)
+
+  def index(conn, _params) do
+    app_scripts = APPScripts.list_app_scripts()
+    render(conn, :index, app_scripts: app_scripts)
+  end
+
+  def create(conn, %{"app_script" => app_script_params}) do
+    with {:ok, %APP{} = app_script} <- APPScripts.create_app_script(app_script_params) do
+      conn
+      |> put_status(:created)
+      |> render(:show, app_script: app_script)
+    end
+  end
+
+  def show(conn, %{"app_name" => name}) do
+    app_script = APPScripts.get_app_script_by_name(name)
+    render(conn, :show, app_script: app_script)
+  end
+
+  def update(conn, %{"id" => id, "app_script" => app_script_params}) do
+    app_script = APPScripts.get_app_script!(id)
+
+    with {:ok, %APP{} = app_script} <- APPScripts.update_app_script(app_script, app_script_params) do
+      render(conn, :show, app_script: app_script)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    app_script = APPScripts.get_app_script!(id)
+
+    with {:ok, %APP{}} <- APPScripts.delete_app_script(app_script) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/core/lib/core_web/controllers/app_script_controller.ex
+++ b/core/lib/core_web/controllers/app_script_controller.ex
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule CoreWeb.APPScriptController do
   use CoreWeb, :controller
 

--- a/core/lib/core_web/controllers/app_script_json.ex
+++ b/core/lib/core_web/controllers/app_script_json.ex
@@ -1,0 +1,25 @@
+defmodule CoreWeb.APPScriptJSON do
+  alias Core.APPScripts.APP
+
+  @doc """
+  Renders a list of app_scripts.
+  """
+  def index(%{app_scripts: app_scripts}) do
+    %{data: for(app_script <- app_scripts, do: data(app_script))}
+  end
+
+  @doc """
+  Renders a single app_script.
+  """
+  def show(%{app_script: app_script}) do
+    %{data: data(app_script)}
+  end
+
+  defp data(%APP{} = app_script) do
+    %{
+      id: app_script.id,
+      name: app_script.name,
+      script: app_script.script
+    }
+  end
+end

--- a/core/lib/core_web/controllers/app_script_json.ex
+++ b/core/lib/core_web/controllers/app_script_json.ex
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule CoreWeb.APPScriptJSON do
   alias Core.APPScripts.APP
 

--- a/core/lib/core_web/router.ex
+++ b/core/lib/core_web/router.ex
@@ -68,6 +68,12 @@ defmodule CoreWeb.Router do
 
     # Invoke function
     post("/fn/:module_name/:function_name", FunctionController, :invoke)
+
+    # APP scripts routes
+    get("/app", APPScriptController, :index)
+    post("/app", APPScriptController, :create)
+    get("/app/:app_name", APPScriptController, :show)
+    # delete("/app/:app_name", AppScriptController, :delete)
   end
 
   # Enable LiveDashboard in development

--- a/core/priv/repo/migrations/20230720095620_create_app_scripts.exs
+++ b/core/priv/repo/migrations/20230720095620_create_app_scripts.exs
@@ -1,0 +1,14 @@
+defmodule Core.Repo.Migrations.CreateAppScripts do
+  use Ecto.Migration
+
+  def change do
+    create table(:app_scripts) do
+      add(:name, :string)
+      add(:script, :string)
+
+      timestamps()
+    end
+
+    create(unique_index(:app_scripts, [:name]))
+  end
+end

--- a/core/priv/repo/migrations/20230720095620_create_app_scripts.exs
+++ b/core/priv/repo/migrations/20230720095620_create_app_scripts.exs
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule Core.Repo.Migrations.CreateAppScripts do
   use Ecto.Migration
 

--- a/core/test/core/app_scripts_test.exs
+++ b/core/test/core/app_scripts_test.exs
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule Core.APPScriptsTest do
   use Core.DataCase
 

--- a/core/test/core/app_scripts_test.exs
+++ b/core/test/core/app_scripts_test.exs
@@ -1,0 +1,64 @@
+defmodule Core.APPScriptsTest do
+  use Core.DataCase
+
+  alias Core.APPScripts
+
+  describe "app_scripts" do
+    alias Core.APPScripts.APP
+
+    import Core.APPScriptsFixtures
+
+    @invalid_attrs %{name: nil, script: nil}
+
+    test "list_app_scripts/0 returns all app_scripts" do
+      app_script = app_script_fixture()
+      assert APPScripts.list_app_scripts() == [app_script]
+    end
+
+    test "get_app_script!/1 returns the app_script with given id" do
+      app_script = app_script_fixture()
+      assert APPScripts.get_app_script!(app_script.id) == app_script
+    end
+
+    test "create_app_script/1 with valid data creates a app_script" do
+      valid_attrs = %{name: "some name", script: "some script"}
+
+      assert {:ok, %APP{} = app_script} = APPScripts.create_app_script(valid_attrs)
+      assert app_script.name == "some name"
+      assert app_script.script == "some script"
+    end
+
+    test "create_app_script/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = APPScripts.create_app_script(@invalid_attrs)
+    end
+
+    test "update_app_script/2 with valid data updates the app_script" do
+      app_script = app_script_fixture()
+      update_attrs = %{name: "some updated name", script: "some updated script"}
+
+      assert {:ok, %APP{} = app_script} = APPScripts.update_app_script(app_script, update_attrs)
+      assert app_script.name == "some updated name"
+      assert app_script.script == "some updated script"
+    end
+
+    test "update_app_script/2 with invalid data returns error changeset" do
+      app_script = app_script_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               APPScripts.update_app_script(app_script, @invalid_attrs)
+
+      assert app_script == APPScripts.get_app_script!(app_script.id)
+    end
+
+    test "delete_app_script/1 deletes the app_script" do
+      app_script = app_script_fixture()
+      assert {:ok, %APP{}} = APPScripts.delete_app_script(app_script)
+      assert_raise Ecto.NoResultsError, fn -> APPScripts.get_app_script!(app_script.id) end
+    end
+
+    test "change_app_script/1 returns a app_script changeset" do
+      app_script = app_script_fixture()
+      assert %Ecto.Changeset{} = APPScripts.change_app_script(app_script)
+    end
+  end
+end

--- a/core/test/core_web/controllers/app_script_controller_test.exs
+++ b/core/test/core_web/controllers/app_script_controller_test.exs
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule CoreWeb.APPScriptControllerTest do
   use CoreWeb.ConnCase
 

--- a/core/test/core_web/controllers/app_script_controller_test.exs
+++ b/core/test/core_web/controllers/app_script_controller_test.exs
@@ -1,0 +1,111 @@
+defmodule CoreWeb.APPScriptControllerTest do
+  use CoreWeb.ConnCase
+
+  import Core.APPScriptsFixtures
+
+  alias Core.Domain.Subjects
+  alias Ecto.Adapters.SQL.Sandbox
+
+  @create_attrs %{
+    name: "some name",
+    script: "some script"
+  }
+  # @update_attrs %{
+  #   name: "some updated name",
+  #   script: "some updated script"
+  # }
+  @invalid_attrs %{name: nil, script: nil}
+
+  setup %{conn: conn} do
+    :ok = Sandbox.checkout(Core.SubjectsRepo)
+    user = Subjects.get_subject_by_name("guest")
+
+    conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{user.token}")
+
+    {:ok, conn: conn}
+  end
+
+  describe "index" do
+    test "lists all app scripts", %{conn: conn} do
+      conn = get(conn, ~p"/v1/app")
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create app_script" do
+    test "renders app_script when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/v1/app", app_script: @create_attrs)
+      assert %{"name" => name} = json_response(conn, 201)["data"]
+      conn = get(conn, ~p"/v1/app/#{name}")
+
+      assert %{
+               "name" => "some name",
+               "script" => "some script"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/v1/app", app_script: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "get single app script" do
+    setup [:create_app_script]
+
+    test "renders app_script", %{conn: conn, app_script: %{name: name}} do
+      conn = get(conn, ~p"/v1/app/#{name}")
+
+      assert %{
+               "name" => "some name",
+               "script" => "some script"
+             } = json_response(conn, 200)["data"]
+    end
+  end
+
+  # describe "update app_script" do
+  #   setup [:create_app_script]
+  #
+  #   test "renders app_script when data is valid", %{
+  #     conn: conn,
+  #     app_script: %APP{name: name} = app_script
+  #   } do
+  #     conn = put(conn, ~p"/v1/app/#{}", app_script: @update_attrs)
+  #     assert %{"name" => ^id} = json_response(conn, 200)["data"]
+  #
+  #     conn = get(conn, ~p"/v1/app/#{id}")
+  #
+  #     assert %{
+  #              "id" => ^id,
+  #              "name" => "some updated name",
+  #              "script" => "some updated script"
+  #            } = json_response(conn, 200)["data"]
+  #   end
+  #
+  #   test "renders errors when data is invalid", %{conn: conn, app_script: app_script} do
+  #     conn = put(conn, ~p"/v1/app/#{app_script}", app_script: @invalid_attrs)
+  #     assert json_response(conn, 422)["errors"] != %{}
+  #   end
+  # end
+
+  # describe "delete app_script" do
+  #   setup [:create_app_script]
+
+  #   test "deletes chosen app_script", %{conn: conn, app_script: app_script} do
+  #     conn = delete(conn, ~p"/v1/app/#{app_script}")
+  #     assert response(conn, 204)
+
+  #     assert_error_sent(404, fn ->
+  #       get(conn, ~p"/v1/app/#{app_script}")
+  #     end)
+  #   end
+  # end
+
+  defp create_app_script(_) do
+    app_script = app_script_fixture()
+    %{app_script: app_script}
+  end
+end

--- a/core/test/support/fixtures/app_scripts_fixtures.ex
+++ b/core/test/support/fixtures/app_scripts_fixtures.ex
@@ -1,3 +1,16 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 defmodule Core.APPScriptsFixtures do
   @moduledoc """
   This module defines test helpers for creating

--- a/core/test/support/fixtures/app_scripts_fixtures.ex
+++ b/core/test/support/fixtures/app_scripts_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Core.APPScriptsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Core.APPScripts` context.
+  """
+
+  @doc """
+  Generate a app_script.
+  """
+  def app_script_fixture(attrs \\ %{}) do
+    {:ok, app_script} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        script: "some script"
+      })
+      |> Core.APPScripts.create_app_script()
+
+    app_script
+  end
+end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -231,7 +231,26 @@ components:
                 total:
                   type: integer
                   description: The total amount of events that was passed
-
+    app_create_update:
+      type: object
+      properties:
+        name:
+          description: Name of the APP script
+          type: string
+        file:
+          type: string
+          format: binary
+          description: File with the APP script
+    single_app_result:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            name:
+              type: string
+            content:
+              type: string
     error:
       type: object
       required:
@@ -533,5 +552,81 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/invoke_result"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+  /v1/app:
+    # GET /app
+    get:
+      summary: List current APP scripts
+      operationId: list_app
+      description: List all APP scripts
+      tags:
+        - app
+      responses:
+        "200":
+          description: An array of APP scripts names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/module_names_result"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+    # POST /app
+    post:
+      summary: Create new APP script
+      operationId: create_app
+      description: Create a new APP script
+      tags:
+        - app
+      requestBody:
+        description: APP to create
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/function_create_update"
+            encoding:
+              code:
+                contentType: application/octet-stream
+      responses:
+        "201":
+          $ref: "#/components/responses/null_response"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+  /v1/app/{app_name}:
+    # GET /app/{app}
+    get:
+      summary: Show APP info
+      operationId: show_app_by_name
+      description: Get APP data (name, content of script)
+      tags:
+        - app
+      parameters:
+        - $ref: "#/components/parameters/module_name"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/single_app_result"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+      # DELETE /app/{app}
+    delete:
+      summary: Delete APP
+      operationId: delete_app
+      description: Delete single APP
+      tags:
+        - app
+      parameters:
+        - $ref: "#/components/parameters/module_name"
+      responses:
+        "200":
+          $ref: "#/components/responses/null_response"
         default:
           $ref: "#/components/responses/unexpected_error"


### PR DESCRIPTION
This PR adds several endpoints for APP scripts. An App script has a name and the content string

- Get /app : list all app scripts
- Post /app: create a new app script
- Get /app/{name}: get a specific app script by name
- Delete /app/{name}: delete an app script