### PR TITLE
Refactor invocation

### DIFF
--- a/core/lib/core/adapters/commands/test.ex
+++ b/core/lib/core/adapters/commands/test.ex
@@ -24,7 +24,7 @@ defmodule Core.Adapters.Commands.Test do
   end
 
   @impl true
-  def send_invoke_with_code(_worker, function, _args) do
+  def send_invoke_with_code(_worker, _handler, function) do
     {:ok, %InvokeResult{result: function.name}}
   end
 end

--- a/core/lib/core/adapters/commands/worker.ex
+++ b/core/lib/core/adapters/commands/worker.ex
@@ -45,8 +45,8 @@ defmodule Core.Adapters.Commands.Worker do
   end
 
   @impl true
-  def send_invoke_with_code(worker, worker_handler, %FunctionStruct{code: _} = func) do
-    worker_addr = {worker_handler, worker}
+  def send_invoke_with_code(_worker, worker_handler, %FunctionStruct{code: _} = func) do
+    worker_addr = worker_handler
     cmd = {:invoke, func}
 
     Logger.info("Sending invoke with code #{func.module}/#{func.name} to #{inspect(worker_addr)}")

--- a/core/lib/core/domain/ports/commands.ex
+++ b/core/lib/core/domain/ports/commands.ex
@@ -23,8 +23,8 @@ defmodule Core.Domain.Ports.Commands do
   @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @callback send_invoke(atom(), String.t(), String.t(), map()) ::
-              {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, any()}
-  @callback send_invoke_with_code(atom(), FunctionStruct.t(), map()) ::
+              {:ok, InvokeResult.t()} | {:error, :code_not_found, pid()} | {:error, any()}
+  @callback send_invoke_with_code(atom(), pid(), FunctionStruct.t()) ::
               {:ok, InvokeResult.t()} | {:error, any()}
 
   @doc """
@@ -45,6 +45,6 @@ defmodule Core.Domain.Ports.Commands do
   and a function struct.
   """
   @spec send_invoke_with_code(atom(), pid(), FunctionStruct.t()) ::
-          {:ok, InvokeResult.t()} | {:error, String.t()}
+          {:ok, InvokeResult.t()} | {:error, any()}
   defdelegate send_invoke_with_code(worker, worker_handler, function), to: @adapter
 end

--- a/core/lib/core/domain/ports/commands.ex
+++ b/core/lib/core/domain/ports/commands.ex
@@ -32,16 +32,19 @@ defmodule Core.Domain.Ports.Commands do
   It requires a worker (a fully qualified name of another node with the :worker actor on) and function arguments can be empty.
   """
   @spec send_invoke(atom(), String.t(), String.t(), map()) ::
-          {:ok, InvokeResult.t()} | {:error, :code_not_found} | {:error, String.t()}
+          {:ok, InvokeResult.t()} | {:error, :code_not_found, pid()} | {:error, any()}
   defdelegate send_invoke(worker, f_name, ns, args), to: @adapter
 
   @doc """
   Sends an invoke command to a worker passing a struct with the function name, module and the code (wasm file binary).
+  The command is sent directly to an handler PID in the Worker, which should have already received the
+  invoke_with_code request.
+  The arguments of the call are already saved Worker-side.
   The worker will store the wasm file in its cache, so subsequent invokes can be done without passing the code.
-  It requires a worker (a fully qualified name of another node with the :worker actor on), a function struct and
-  (optionally empty) function arguments.
+  It requires a worker (a fully qualified name of another node with the :worker actor on), a PID for the handler
+  and a function struct.
   """
-  @spec send_invoke_with_code(atom(), FunctionStruct.t(), map()) ::
+  @spec send_invoke_with_code(atom(), pid(), FunctionStruct.t()) ::
           {:ok, InvokeResult.t()} | {:error, String.t()}
-  defdelegate send_invoke_with_code(worker, function, args), to: @adapter
+  defdelegate send_invoke_with_code(worker, worker_handler, function), to: @adapter
 end

--- a/core/test/core/integration/invoke_test.exs
+++ b/core/test/core/integration/invoke_test.exs
@@ -164,10 +164,10 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, :somepid} end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke_with_code, fn _worker, function, _args ->
+      |> Mox.expect(:send_invoke_with_code, fn _worker, _handler, function ->
         {:ok, %InvokeResult{result: function}}
       end)
 

--- a/core/test/core/integration/invoke_test.exs
+++ b/core/test/core/integration/invoke_test.exs
@@ -164,7 +164,7 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, :somepid} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, self()} end)
 
       Core.Commands.Mock
       |> Mox.expect(:send_invoke_with_code, fn _worker, _handler, function ->

--- a/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -404,7 +404,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, :somepid} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}")
       assert response(conn, 200)

--- a/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -404,7 +404,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, :somepid} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, self()} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}")
       assert response(conn, 200)

--- a/worker/config/config.exs
+++ b/worker/config/config.exs
@@ -20,6 +20,8 @@ config :logger, :console,
   metadata: [:request_id, :file, :line]
 
 # --- Worker Configs ---
+config :worker, Worker.Domain.Ports.WaitForCode, adapter: Worker.Adapters.WaitForCode
+
 config :worker, Worker.Domain.Ports.Runtime.Provisioner,
   adapter: Worker.Adapters.Runtime.Wasm.Provisioner
 

--- a/worker/lib/worker/adapters/wait_for_code/handler.ex
+++ b/worker/lib/worker/adapters/wait_for_code/handler.ex
@@ -1,0 +1,38 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Adapters.WaitForCode.Handler do
+  @moduledoc """
+  Implements GenServer behaviour. Waits for the missing code of functions after
+  a previous attempt at invocation.
+  """
+  alias Data.FunctionStruct
+  alias Worker.Domain.InvokeFunction
+  use GenServer
+  require Logger
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  @impl true
+  def init(args) do
+    {:ok, %{ivk_args: args}}
+  end
+
+  @impl true
+  def handle_call({:invoke, %FunctionStruct{code: _} = function}, _from, %{ivk_args: args}) do
+    {:stop, :normal, InvokeFunction.invoke(function, args), %{}}
+  end
+end

--- a/worker/lib/worker/adapters/wait_for_code/handler.ex
+++ b/worker/lib/worker/adapters/wait_for_code/handler.ex
@@ -28,6 +28,7 @@ defmodule Worker.Adapters.WaitForCode.Handler do
 
   @impl true
   def init(args) do
+    Logger.info("Starting GenServer waiting for code")
     {:ok, %{ivk_args: args}}
   end
 

--- a/worker/lib/worker/adapters/wait_for_code/test.ex
+++ b/worker/lib/worker/adapters/wait_for_code/test.ex
@@ -1,0 +1,23 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Adapters.WaitForCode.Test do
+  @moduledoc false
+  @behaviour Worker.Domain.Ports.WaitForCode
+
+  @impl true
+  def wait_for_code(_args) do
+    {:ok, self()}
+  end
+end

--- a/worker/lib/worker/adapters/wait_for_code/wait_for_code.ex
+++ b/worker/lib/worker/adapters/wait_for_code/wait_for_code.ex
@@ -1,0 +1,26 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Adapters.WaitForCode do
+  @moduledoc """
+    Implements WaitForCode behaviour. Simply spawns the Handler GenServer
+    when wait_for_code/1 is called.
+  """
+  alias Worker.Adapters.WaitForCode.Handler
+  @behaviour Worker.Domain.Ports.WaitForCode
+
+  def wait_for_code(args) do
+    GenServer.start(Handler, args)
+  end
+end

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -17,6 +17,7 @@ defmodule Worker.Domain.InvokeFunction do
   Contains functions used to run function runtimes. Side effects (e.g. docker interaction) are delegated to ports and adapters.
   """
 
+  alias Worker.Domain.Ports.WaitForCode
   alias Worker.Domain.Ports.Runtime.Runner
   alias Worker.Domain.ProvisionResource
 
@@ -45,8 +46,16 @@ defmodule Worker.Domain.InvokeFunction do
     f = struct(FunctionStruct, function)
     Logger.info("API: Invoking function #{mod}/#{name}")
 
-    with {:ok, resource} <- ProvisionResource.provision(f) do
-      Runner.run_function(function, args, resource)
+    case ProvisionResource.provision(f) do
+      {:ok, resource} ->
+        Runner.run_function(function, args, resource)
+
+      {:error, :code_not_found} ->
+        {:ok, pid} = WaitForCode.wait_for_code(args)
+        {:error, :code_not_found, pid}
+
+      {:error, err} ->
+        {:error, err}
     end
   end
 

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -17,8 +17,8 @@ defmodule Worker.Domain.InvokeFunction do
   Contains functions used to run function runtimes. Side effects (e.g. docker interaction) are delegated to ports and adapters.
   """
 
-  alias Worker.Domain.Ports.WaitForCode
   alias Worker.Domain.Ports.Runtime.Runner
+  alias Worker.Domain.Ports.WaitForCode
   alias Worker.Domain.ProvisionResource
 
   alias Data.FunctionStruct

--- a/worker/lib/worker/domain/ports/wait_for_code.ex
+++ b/worker/lib/worker/domain/ports/wait_for_code.ex
@@ -1,0 +1,28 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Domain.Ports.WaitForCode do
+  @moduledoc """
+  Handles invocations where the code was not found. The underlying adapter should implement a GenServer.
+  """
+  @callback wait_for_code(map()) :: {:ok, pid()} | {:error, any}
+
+  @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @doc """
+  Waits for the invocation with code to be sent by the Core. Should spawn a GenServer.
+  """
+  @spec wait_for_code(map()) :: {:ok, pid()} | {:error, any}
+  defdelegate wait_for_code(args), to: @adapter
+end

--- a/worker/test/support/mocks.ex
+++ b/worker/test/support/mocks.ex
@@ -18,3 +18,4 @@ Mox.defmock(Worker.Cleaner.Mock, for: Worker.Domain.Ports.Runtime.Cleaner)
 
 Mox.defmock(Worker.ResourceCache.Mock, for: Worker.Domain.Ports.ResourceCache)
 Mox.defmock(Worker.NodeInfoStorage.Mock, for: Worker.Domain.Ports.NodeInfoStorage)
+Mox.defmock(Worker.WaitForCode.Mock, for: Worker.Domain.Ports.WaitForCode)

--- a/worker/test/unit/invoke_test.exs
+++ b/worker/test/unit/invoke_test.exs
@@ -36,6 +36,7 @@ defmodule InvokeTest do
       Worker.Runner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Runner.Test)
       Worker.Provisioner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Provisioner.Test)
       Worker.ResourceCache.Mock |> Mox.stub_with(Worker.Adapters.ResourceCache.Test)
+      Worker.WaitForCode.Mock |> Mox.stub_with(Worker.Adapters.WaitForCode.Test)
       :ok
     end
 
@@ -68,6 +69,15 @@ defmodule InvokeTest do
       Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:error, "creation error"} end)
 
       assert InvokeFunction.invoke(function) == {:error, "creation error"}
+    end
+
+    test "should return {:error, :code_not_found, pid} when the code is not found", %{
+      function: function
+    } do
+      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _ -> :resource_not_found end)
+      Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:error, :code_not_found} end)
+      assert {:error, :code_not_found, handler_pid} = InvokeFunction.invoke(function)
+      assert is_pid(handler_pid)
     end
   end
 end


### PR DESCRIPTION
This PR changes the way Core and Worker components handle invocations.

In the flow
```
invoke -> {:error, :code_not_found} -> invoke_with_code
```

the function arguments were sent twice, wasting network traffic in case of large payload.

With this PR, the Worker spawns a `GenServer` to handle the `invoke_with_code` request, ending the previous process and keeping the args of the call in memory. The Core sends the second request directly to the new process, instead of the `:worker` process that normally receives requests.
