### PR TITLE
Invoke and scheduling optimization

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -30,6 +30,9 @@ config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Conne
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
 config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
 
+config :core, CoreWeb.FunctionController,
+  store_on_create: System.get_env("STORE_ON_CREATE") || "true"
+
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]
 

--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -30,9 +30,6 @@ config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Conne
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
 config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
 
-config :core, CoreWeb.FunctionController,
-  store_on_create: System.get_env("STORE_ON_CREATE") || "true"
-
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]
 

--- a/core/config/runtime.exs
+++ b/core/config/runtime.exs
@@ -16,6 +16,8 @@ import Config
 
 config :iex, default_prompt: ">>>"
 
+config :core, store_on_create: System.get_env("STORE_ON_CREATE") || "true"
+
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration

--- a/core/lib/application.ex
+++ b/core/lib/application.ex
@@ -40,9 +40,9 @@ defmodule Core.Application do
       ## Core Children
       Core.Repo,
       Core.SubjectsRepo,
+      {Core.Adapters.Telemetry.Supervisor, []},
       {Cluster.Supervisor, [topologies, [name: Core.ClusterSupervisor]]},
       {Core.Adapters.Subjects.Cache, []},
-      {Core.Adapters.Telemetry.Supervisor, []},
       {Core.Adapters.Connectors.Supervisor, []},
       {Core.Adapters.DataSinks.Supervisor, []}
     ]

--- a/core/lib/core/adapters/commands/test.ex
+++ b/core/lib/core/adapters/commands/test.ex
@@ -27,4 +27,9 @@ defmodule Core.Adapters.Commands.Test do
   def send_invoke_with_code(_worker, _handler, function) do
     {:ok, %InvokeResult{result: function.name}}
   end
+
+  @impl true
+  def send_store_function(_worker, _func) do
+    :ok
+  end
 end

--- a/core/lib/core/adapters/commands/worker.ex
+++ b/core/lib/core/adapters/commands/worker.ex
@@ -56,4 +56,16 @@ defmodule Core.Adapters.Commands.Worker do
       {:error, err} -> {:error, err}
     end
   end
+
+  @impl true
+  def send_store_function(worker, %FunctionStruct{} = function) do
+    worker_addr = {:worker, worker}
+    cmd = {:store_function, function}
+
+    Logger.info(
+      "Sending store_function for #{function.module}/#{function.name} to #{inspect(worker_addr)}"
+    )
+
+    GenServer.call(worker_addr, cmd, 60_000)
+  end
 end

--- a/core/lib/core/adapters/commands/worker.ex
+++ b/core/lib/core/adapters/commands/worker.ex
@@ -37,7 +37,7 @@ defmodule Core.Adapters.Commands.Worker do
     cmd = {:invoke, %{name: name, module: mod}, args}
     Logger.info("Sending invoke for #{mod}/#{name} to #{inspect(worker_addr)}")
 
-    case GenServer.call(worker_addr, cmd, 30_000) do
+    case GenServer.call(worker_addr, cmd, 60_000) do
       {:ok, result} -> {:ok, %InvokeResult{result: result}}
       {:error, :code_not_found, handler} -> {:error, :code_not_found, handler}
       {:error, err} -> {:error, err}
@@ -51,7 +51,7 @@ defmodule Core.Adapters.Commands.Worker do
 
     Logger.info("Sending invoke with code #{func.module}/#{func.name} to #{inspect(worker_addr)}")
 
-    case GenServer.call(worker_addr, cmd, 30_000) do
+    case GenServer.call(worker_addr, cmd, 60_000) do
       {:ok, result} -> {:ok, %InvokeResult{result: result}}
       {:error, err} -> {:error, err}
     end

--- a/core/lib/core/adapters/telemetry/test.ex
+++ b/core/lib/core/adapters/telemetry/test.ex
@@ -17,10 +17,10 @@ defmodule Core.Adapters.Telemetry.Test do
   @behaviour Core.Domain.Ports.Telemetry.Metrics
 
   @impl true
-  def resources(_worker) do
+  def resources(worker) do
     {:ok,
      struct(Data.Worker, %{
-       name: :nonode@nohost,
+       name: worker,
        resources: %Data.Worker.Metrics{
          cpu: 1,
          load_avg: %{l1: 1, l5: 5, l15: 15},

--- a/core/lib/core/domain/invoker.ex
+++ b/core/lib/core/domain/invoker.ex
@@ -58,13 +58,12 @@ defmodule Core.Domain.Invoker do
 
     case Functions.get_code_by_name_in_mod!(ivk.function, ivk.module) do
       [f] ->
-        func =
-          struct(FunctionStruct, %{
-            name: ivk.function,
-            module: ivk.module,
-            code: f.code,
-            metadata: struct(FunctionMetadata)
-          })
+        func = %FunctionStruct{
+          name: ivk.function,
+          module: ivk.module,
+          code: f.code,
+          metadata: struct(FunctionMetadata, %{})
+        }
 
         with {:ok, worker} <- Nodes.worker_nodes() |> Scheduler.select(func) do
           update_concurrent(worker, +1)

--- a/core/lib/core/domain/policies/default.ex
+++ b/core/lib/core/domain/policies/default.ex
@@ -27,14 +27,21 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.Empty do
       |> Enum.filter(fn %Data.Worker{resources: %{memory: %{available: available}}} ->
         c <= available
       end)
-      |> Enum.max_by(fn %Data.Worker{resources: %{memory: %{available: available}}} ->
-        available
-      end)
+      |> Enum.max_by(
+        fn %Data.Worker{resources: %{memory: %{available: available}}} ->
+          available
+        end,
+        fn -> nil end
+      )
 
     case selected_worker do
       nil -> {:error, :no_valid_workers}
       %Data.Worker{} = wrk -> {:ok, wrk}
     end
+  end
+
+  def select(%Empty{}, _, %Data.FunctionStruct{metadata: nil}) do
+    {:error, :no_function_metadata}
   end
 
   def select(%Empty{}, [], _) do

--- a/core/lib/core/domain/ports/commands.ex
+++ b/core/lib/core/domain/ports/commands.ex
@@ -26,6 +26,8 @@ defmodule Core.Domain.Ports.Commands do
               {:ok, InvokeResult.t()} | {:error, :code_not_found, pid()} | {:error, any()}
   @callback send_invoke_with_code(atom(), pid(), FunctionStruct.t()) ::
               {:ok, InvokeResult.t()} | {:error, any()}
+  @callback send_store_function(atom(), FunctionStruct.t()) ::
+              :ok | {:error, :invalid_input} | {:error, any()}
 
   @doc """
   Sends an invoke command to a worker passing the function name, module and args.
@@ -47,4 +49,13 @@ defmodule Core.Domain.Ports.Commands do
   @spec send_invoke_with_code(atom(), pid(), FunctionStruct.t()) ::
           {:ok, InvokeResult.t()} | {:error, any()}
   defdelegate send_invoke_with_code(worker, worker_handler, function), to: @adapter
+
+  @doc """
+  Sends a store_function command to a worker, passing a function struct, containing (at least) the function's name, module and code.
+  The worker will store the wasm file locally (generally as a raw resource, without initializing).
+  It requires a worker (a fully qualified name of another node with the :worker actor on) and a functions struct.
+  """
+  @spec send_store_function(atom(), FunctionStruct.t()) ::
+          :ok | {:error, :invalid_input} | {:error, any()}
+  defdelegate send_store_function(worker, function), to: @adapter
 end

--- a/core/lib/core/domain/scheduler.ex
+++ b/core/lib/core/domain/scheduler.ex
@@ -42,8 +42,6 @@ defmodule Core.Domain.Scheduler do
       |> Enum.filter(&match?({:ok, _}, &1))
       |> Enum.map(&elem(&1, 1))
 
-    IO.puts("here #{inspect(workers)}")
-
     case resources do
       [] ->
         # If resources are unavailable for some reason, pick a random worker

--- a/core/lib/core/domain/scheduler.ex
+++ b/core/lib/core/domain/scheduler.ex
@@ -33,11 +33,6 @@ defmodule Core.Domain.Scheduler do
     {:error, :no_workers}
   end
 
-  def select([w], _) do
-    Logger.info("Scheduler: selection with only one worker #{inspect(w)}")
-    {:ok, w}
-  end
-
   def select(workers, function) do
     Logger.info("Scheduler: selection with #{length(workers)} workers")
 
@@ -46,6 +41,8 @@ defmodule Core.Domain.Scheduler do
       Enum.map(workers, &Metrics.resources/1)
       |> Enum.filter(&match?({:ok, _}, &1))
       |> Enum.map(&elem(&1, 1))
+
+    IO.puts("here #{inspect(workers)}")
 
     case resources do
       [] ->

--- a/core/lib/core/domain/worker_resource_handler.ex
+++ b/core/lib/core/domain/worker_resource_handler.ex
@@ -1,0 +1,37 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.WorkerResourceHandler do
+  @moduledoc """
+  Provides functions to handle resources on workers.
+  """
+  alias Core.Domain.Ports.Commands
+
+  @doc """
+  Sends a store_function request to the given worker, for the given function.
+  The logic is delegated to the Commands adapter.
+
+  ## Parameters
+  - `worker`: the worker on which the function will be stored
+  - `function`: the function that will be stored
+
+  ## Returns
+  - `:ok` if the function was stored successfully
+  - `{:error, err}` if any error was raised during the operation
+  """
+  @spec store_function(atom(), Data.FunctionStruct.t()) :: :ok | {:error, any()}
+  def store_function(worker, function) do
+    Commands.send_store_function(worker, function)
+  end
+end

--- a/core/lib/core_web/controllers/function_controller.ex
+++ b/core/lib/core_web/controllers/function_controller.ex
@@ -223,6 +223,13 @@ defmodule CoreWeb.FunctionController do
       {:DOWN, ^ref, _, _, _} ->
         Logger.info("Function controller: code sent to all workers")
         :ok
+
+      {:DOWN, ^ref, _, _, reason} ->
+        Logger.warn(
+          "Something went wrong while sending code to all workers (process exited with reason #{reason})"
+        )
+
+        :ok
     end
   end
 

--- a/core/lib/core_web/controllers/function_controller.ex
+++ b/core/lib/core_web/controllers/function_controller.ex
@@ -234,7 +234,8 @@ defmodule CoreWeb.FunctionController do
   end
 
   defp do_wait_for_workers(stream, false) do
-    Stream.run(stream)
+    _ = Process.spawn(fn -> do_wait_for_workers(stream, true) end, [])
+    :ok
   end
 
   defp store_on_create do

--- a/core/test/core/integration/invoke_test.exs
+++ b/core/test/core/integration/invoke_test.exs
@@ -16,7 +16,7 @@ defmodule Core.InvokeTest do
   use CoreWeb.ConnCase
 
   alias Core.Domain.Invoker
-  alias Data.{FunctionStruct, InvokeParams, InvokeResult}
+  alias Data.{FunctionMetadata, FunctionStruct, InvokeParams, InvokeResult}
 
   import Core.{FunctionsFixtures, ModulesFixtures}
 
@@ -174,7 +174,8 @@ defmodule Core.InvokeTest do
       f_out = %FunctionStruct{
         name: function.name,
         module: module.name,
-        code: function.code
+        code: function.code,
+        metadata: struct(FunctionMetadata, %{})
       }
 
       pars = %InvokeParams{function: function.name, module: module.name}

--- a/core/test/core/unit/policies/app_policy_test.exs
+++ b/core/test/core/unit/policies/app_policy_test.exs
@@ -471,7 +471,23 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       assert app_impl.select(script, [], function) == {:error, :no_workers}
     end
 
-    test "select should return {:error, :no_valid_workers} when given a non-empty worker list, but finding no valid workers" do
+    test "select should return {:error, :no_valid_workers} when given a non-empty worker list, but finding no valid workers",
+         %{impl: app_impl, script: script, function: function, workers: [wrk1, wrk2, _]} do
+      wrk1 =
+        wrk1
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      wrk2 =
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      invalidate_workers = [wrk1, wrk2]
+
+      assert app_impl.select(script, invalidate_workers, function) == {:error, :no_valid_workers}
     end
 
     test "select should return {:error, :no_matching_tag} when the function's tag is not found in the script and default tag is undefined",

--- a/core/test/core/unit/policies/default_policy_test.exs
+++ b/core/test/core/unit/policies/default_policy_test.exs
@@ -1,0 +1,126 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.Policies.DefaultPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Domain.Policies.SchedulingPolicy
+  alias Data.Configurations.Empty
+  alias Data.FunctionMetadata
+  alias Data.FunctionStruct
+  alias Data.Worker
+  alias Data.Worker.Metrics
+
+  setup_all do
+    implementation = SchedulingPolicy.impl_for(%Empty{})
+    %{impl: implementation}
+  end
+
+  describe "protocol" do
+    test "the module should be a valid implementation of the SchedulingPolicy protocol for the Data.Configurations.Empty type",
+         %{impl: def_impl} do
+      assert Protocol.assert_impl!(SchedulingPolicy, Empty) == :ok
+      assert def_impl != nil
+    end
+  end
+
+  describe "select" do
+    setup do
+      wrk = %Worker{
+        name: "worker@localhost",
+        long_name: "worker1",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 256, total: 512}
+        }
+      }
+
+      workers = [
+        wrk,
+        wrk
+        |> Map.put(:long_name, "worker2")
+      ]
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      %{
+        workers: workers,
+        function: function
+      }
+    end
+
+    test "select should return the worker with the highest amount of memory available",
+         %{impl: def_impl, workers: [wrk1, wrk2], function: function} do
+      # this test case will break if we change the inner logic of the default scheduling policy
+      wrk2 = wrk2 |> Map.put(:resources, %Metrics{memory: %{available: 512, total: 512}})
+      {:ok, wrk} = def_impl.select(%Empty{}, [wrk1, wrk2], function)
+      assert wrk2 == wrk
+    end
+
+    test "select should return {:error, :no_workers} when given an empty worker list",
+         %{impl: def_impl, function: function} do
+      assert def_impl.select(%Empty{}, [], function) == {:error, :no_workers}
+    end
+
+    test "select should return {:error, :no_valid_workers} when given a non-empty worker list, but finding no valid workers",
+         %{impl: def_impl, workers: [wrk1, wrk2], function: function} do
+      wrk1 =
+        wrk1
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      wrk2 =
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        })
+
+      invalidate_workers = [wrk1, wrk2]
+
+      assert def_impl.select(%Empty{}, invalidate_workers, function) ==
+               {:error, :no_valid_workers}
+    end
+
+    test "select should return {:error, :no_function_metadata} when given a function with no associated metadata",
+         %{impl: def_impl, workers: workers} do
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod"
+      }
+
+      assert def_impl.select(%Empty{}, workers, function) ==
+               {:error, :no_function_metadata}
+    end
+  end
+end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -145,6 +145,10 @@ components:
           type: string
           format: binary
           description: File with the code of the function
+        wait_for_workers:
+          description: Whether to wait for all workers to receive the code of the function. If false, the request returns as soon as the creation request terminates.
+          type: boolean
+          default: true
         events:
           description: Events that can trigger the function
           type: array

--- a/worker/config/config.exs
+++ b/worker/config/config.exs
@@ -33,6 +33,9 @@ config :worker, Worker.Domain.Ports.Runtime.Supervisor,
 
 config :worker, Worker.Domain.Ports.ResourceCache, adapter: Worker.Adapters.ResourceCache
 
+config :worker, Worker.Domain.Ports.RawResourceStorage,
+  adapter: Worker.Adapters.RawResourceStorage
+
 config :worker, Worker.Domain.Ports.NodeInfoStorage,
   adapter: Worker.Adapters.NodeInfoStorage.LocalInfoStorage
 
@@ -40,6 +43,7 @@ config :worker, Worker.Domain.Ports.NodeInfoStorage.Supervisor,
   adapter: Worker.Adapters.NodeInfoStorage.Supervisor
 
 config :worker, Worker.Adapters.NodeInfoStorage.LocalInfoStorage, path: "/tmp/node_info"
+config :worker, Worker.Adapters.RawResourceStorage, prefix: "/tmp/funless/"
 
 config :os_mon,
   start_cpu_sup: true,

--- a/worker/config/test.exs
+++ b/worker/config/test.exs
@@ -25,6 +25,8 @@ config :worker, Worker.Domain.Ports.Runtime.Runner, adapter: Worker.Runner.Mock
 config :worker, Worker.Domain.Ports.Runtime.Cleaner, adapter: Worker.Cleaner.Mock
 config :worker, Worker.Domain.Ports.NodeInfoStorage, adapter: Worker.NodeInfoStorage.Mock
 
+config :worker, Worker.Adapters.RawResourceStorage, prefix: "/tmp/funless/test/"
+
 # --- Libcluster Configs ---
 config :worker,
   topologies: [

--- a/worker/config/test.exs
+++ b/worker/config/test.exs
@@ -19,6 +19,7 @@ config :logger, level: :warn, backends: []
 
 # --- Worker Configs ---
 config :worker, Worker.Domain.Ports.ResourceCache, adapter: Worker.ResourceCache.Mock
+config :worker, Worker.Domain.Ports.RawResourceStorage, adapter: Worker.RawResourceStorage.Mock
 config :worker, Worker.Domain.Ports.Runtime.Provisioner, adapter: Worker.Provisioner.Mock
 config :worker, Worker.Domain.Ports.Runtime.Runner, adapter: Worker.Runner.Mock
 config :worker, Worker.Domain.Ports.Runtime.Cleaner, adapter: Worker.Cleaner.Mock

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -1,0 +1,213 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Adapters.RawResourceStorage do
+  @moduledoc """
+    Implements the RawResourceStorage behaviour.
+    Raw resources (i.e. binaries) are saved in files.
+  """
+
+  # TODO: we don't handle any exit reason, we only handle our errors; should actually handle abnormal exits
+  # TODO: better error handling in get(), now every error is translated to "resource not found"
+  @behaviour Worker.Domain.Ports.RawResourceStorage
+
+  @file_prefix :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:prefix)
+  @process_prefix "file_writer_"
+  @registry Worker.Adapters.RawResourceStorage.Registry
+
+  @doc """
+
+  Gets the saved raw resource, if available.
+  In case a process is already writing/deleting it, it waits for it to complete.
+
+  ## Parameters
+  - `function_name`: the name of the function
+  - `module`: the module of the function
+
+  ## Returns
+  - `resource` if the resource is found;
+  - `:resource_not_found` if the resource is not found.
+  """
+  @impl true
+  def get(function_name, module) do
+    process_name = @process_prefix <> "#{module}_#{function_name}"
+
+    case Registry.lookup(@registry, process_name) do
+      [] ->
+        do_get(function_name, module)
+
+      [{pid, _} | _] ->
+        ref = Process.monitor(pid)
+
+        receive do
+          {:DOWN, ^ref, _, _, {:error, _}} ->
+            :resource_not_found
+
+          {:DOWN, ^ref, _, _, _} ->
+            do_get(function_name, module)
+        end
+    end
+  end
+
+  defp do_get(function_name, module) do
+    file_path = get_file_path(function_name, module)
+
+    case File.read(file_path) do
+      {:ok, resource} -> resource
+      {:error, _} -> :resource_not_found
+    end
+  end
+
+  @doc """
+  Inserts a raw resource, using function name and module as key.
+  It spawns and registers a process to perform the file creation, using Worker.Adapters.RawResourceStorage.Registry.
+  The process is monitored as soon as it is spawned.
+  In case a process is already writing/deleting the same file, it monitors that instead.
+
+  If the file was being deleted, this function returns `:ok` if the deletion completes successfully.
+
+  ## Parameters
+  - `function_name`: the name of the function
+  - `module`: the module of the function
+  - `resource`: the resource to store
+
+  ## Returns
+  - `:ok` if everything went well
+  - `{:error, err}` if any error arose during the registration of the process, or the creation of the file
+  """
+  @impl true
+  def insert(function_name, module, resource) do
+    process_name = @process_prefix <> "#{module}_#{function_name}"
+
+    insert_ref =
+      case Registry.lookup(@registry, process_name) do
+        [] ->
+          {_pid, ref} =
+            Process.spawn(
+              __MODULE__,
+              :do_insert,
+              [
+                process_name,
+                function_name,
+                module,
+                resource
+              ],
+              [:monitor]
+            )
+
+          ref
+
+        [{pid, _} | _] ->
+          Process.monitor(pid)
+      end
+
+    receive do
+      {:DOWN, ^insert_ref, _, _, {:error, err}} ->
+        {:error, err}
+
+      {:DOWN, ^insert_ref, _, _, _} ->
+        :ok
+    end
+  end
+
+  defp do_insert(process_name, function_name, module, resource) do
+    case Registry.register(@registry, process_name, nil) do
+      {:ok, _} ->
+        file_path = get_file_path(function_name, module)
+
+        if File.exists?(file_path) do
+          # nothing to do (in the future we should update)
+          :ok
+        else
+          case File.write(file_path, resource) do
+            :ok -> :ok
+            {:error, err} -> exit({:error, err})
+          end
+        end
+
+      {:error, err} ->
+        exit({:error, err})
+    end
+  end
+
+  @doc """
+
+  Deletes a raw resource, if it exists.
+  It spawns and registers a process to perform the file deletion, using Worker.Adapters.RawResourceStorage.Registry.
+  The process is monitored as soon as it is spawned.
+  In case a process is already writing/deleting the same file, it monitors that instead.
+
+  If the file was being created, this function returns `:ok` if the creation completes successfully.
+
+  ## Parameters
+  - `function_name`: the name of the function
+  - `module`: the module of the function
+
+  ## Returns
+  - `:ok` if everything went well
+  - `{:error, err}` if any error arose during the registration of the process, or the deletion of the file
+  """
+  @impl true
+  def delete(function_name, module) do
+    process_name = @process_prefix <> "#{module}_#{function_name}"
+
+    delete_ref =
+      case Registry.lookup(@registry, process_name) do
+        [] ->
+          {_pid, ref} =
+            Process.spawn(
+              __MODULE__,
+              :do_delete,
+              [
+                process_name,
+                function_name,
+                module
+              ],
+              [:monitor]
+            )
+
+          ref
+
+        [{pid, _} | _] ->
+          Process.monitor(pid)
+      end
+
+    receive do
+      {:DOWN, ^delete_ref, _, _, {:error, err}} ->
+        {:error, err}
+
+      {:DOWN, ^delete_ref, _, _, _} ->
+        :ok
+    end
+  end
+
+  defp do_delete(process_name, function_name, module) do
+    case Registry.register(@registry, process_name, nil) do
+      {:ok, _} ->
+        file_path = get_file_path(function_name, module)
+
+        case File.rm(file_path) do
+          :ok -> :ok
+          {:error, err} -> exit({:error, err})
+        end
+
+      {:error, err} ->
+        exit({:error, err})
+    end
+  end
+
+  defp get_file_path(function_name, module) do
+    @file_prefix <> "#{module}_#{function_name}"
+  end
+end

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -53,6 +53,9 @@ defmodule Worker.Adapters.RawResourceStorage do
           {:DOWN, ^ref, _, _, :normal} ->
             do_get(function_name, module)
 
+          {:DOWN, ^ref, _, _, :noproc} ->
+            do_get(function_name, module)
+
           {:DOWN, ^ref, _, _, {:error, _}} ->
             :resource_not_found
 
@@ -116,6 +119,9 @@ defmodule Worker.Adapters.RawResourceStorage do
 
     receive do
       {:DOWN, ^insert_ref, _, _, :normal} ->
+        :ok
+
+      {:DOWN, ^insert_ref, _, _, :noproc} ->
         :ok
 
       {:DOWN, ^insert_ref, _, _, {:error, err}} ->
@@ -196,6 +202,9 @@ defmodule Worker.Adapters.RawResourceStorage do
       {:DOWN, ^delete_ref, _, _, :normal} ->
         :ok
 
+      {:DOWN, ^delete_ref, _, _, :noproc} ->
+        :ok
+
       {:DOWN, ^delete_ref, _, _, {:error, err}} ->
         {:error, err}
 
@@ -212,6 +221,7 @@ defmodule Worker.Adapters.RawResourceStorage do
 
         case File.rm(file_path) do
           :ok -> :ok
+          {:error, :enoent} -> :ok
           {:error, err} -> exit({:error, err})
         end
 
@@ -221,6 +231,6 @@ defmodule Worker.Adapters.RawResourceStorage do
   end
 
   defp get_file_path(function_name, module) do
-    @file_prefix <> "#{module}_#{function_name}"
+    Path.join([@file_prefix, "#{module}_#{function_name}"])
   end
 end

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -18,7 +18,6 @@ defmodule Worker.Adapters.RawResourceStorage do
     Raw resources (i.e. binaries) are saved in files.
   """
 
-  # TODO: better error handling in get(), now every error is translated to "resource not found"
   @behaviour Worker.Domain.Ports.RawResourceStorage
 
   @file_prefix :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:prefix)

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -126,14 +126,17 @@ defmodule Worker.Adapters.RawResourceStorage do
       {:ok, _} ->
         file_path = get_file_path(function_name, module)
 
-        if File.exists?(file_path) do
-          # nothing to do (in the future we should update)
-          :ok
-        else
-          case File.write(file_path, resource) do
-            :ok -> :ok
-            {:error, err} -> exit({:error, err})
+        result =
+          if File.exists?(file_path) do
+            # nothing to do (in the future we should update)
+            :ok
+          else
+            File.write(file_path, resource)
           end
+
+        case result do
+          :ok -> :ok
+          {:error, err} -> exit({:error, err})
         end
 
       {:error, err} ->

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -121,7 +121,8 @@ defmodule Worker.Adapters.RawResourceStorage do
     end
   end
 
-  defp do_insert(process_name, function_name, module, resource) do
+  @spec do_insert(String.t(), String.t(), String.t(), binary()) :: :ok | {:error, any()}
+  def do_insert(process_name, function_name, module, resource) do
     case Registry.register(@registry, process_name, nil) do
       {:ok, _} ->
         file_path = get_file_path(function_name, module)
@@ -195,7 +196,8 @@ defmodule Worker.Adapters.RawResourceStorage do
     end
   end
 
-  defp do_delete(process_name, function_name, module) do
+  @spec do_delete(String.t(), String.t(), String.t()) :: :ok | {:error, any()}
+  def do_delete(process_name, function_name, module) do
     case Registry.register(@registry, process_name, nil) do
       {:ok, _} ->
         file_path = get_file_path(function_name, module)

--- a/worker/lib/worker/adapters/raw_resource_storage/test.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/test.ex
@@ -12,11 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Mox.defmock(Worker.Provisioner.Mock, for: Worker.Domain.Ports.Runtime.Provisioner)
-Mox.defmock(Worker.Runner.Mock, for: Worker.Domain.Ports.Runtime.Runner)
-Mox.defmock(Worker.Cleaner.Mock, for: Worker.Domain.Ports.Runtime.Cleaner)
+defmodule Worker.Adapters.RawResourceStorage.Test do
+  @moduledoc false
+  @behaviour Worker.Domain.Ports.RawResourceStorage
 
-Mox.defmock(Worker.ResourceCache.Mock, for: Worker.Domain.Ports.ResourceCache)
-Mox.defmock(Worker.RawResourceStorage.Mock, for: Worker.Domain.Ports.RawResourceStorage)
-Mox.defmock(Worker.NodeInfoStorage.Mock, for: Worker.Domain.Ports.NodeInfoStorage)
-Mox.defmock(Worker.WaitForCode.Mock, for: Worker.Domain.Ports.WaitForCode)
+  @impl true
+  def get(_name, _mod) do
+    <<0>>
+  end
+
+  @impl true
+  def insert(_name, _mod, _resource) do
+    :ok
+  end
+
+  @impl true
+  def delete(_name, _mod) do
+    :ok
+  end
+end

--- a/worker/lib/worker/adapters/requests/cluster/cluster.ex
+++ b/worker/lib/worker/adapters/requests/cluster/cluster.ex
@@ -16,18 +16,19 @@ defmodule Worker.Adapters.Requests.Cluster do
   @moduledoc """
   Contains functions exposing the Worker API to other processes/nodes in the cluster.
   """
+  alias Data.FunctionStruct
   alias Worker.Domain.InvokeFunction
   alias Worker.Domain.NodeInfo
+  alias Worker.Domain.StoreResource
 
   require Logger
 
   @doc """
     Runs the given `function` using the underlying InvokeFunction.invoke() from the domain.
-    It uses the runtime associated with the function from the cache, if it exists.
-    If the runtime does not exist, it is provisioned and then run.
+    It uses the ExecutionResource associated with the function from the cache, if it exists.
+    If the resource does not exist, it is provisioned and then used.
 
-    The provisioner might request the runtime from the core
-    if no runtime is found, creates the required runtime and runs the function.
+    The provisioner might request the resource from the core, if it's unable to create it on its own.
     Any error encountered by the API calls is forwarded to the sender.
 
     ## Parameters
@@ -49,6 +50,10 @@ defmodule Worker.Adapters.Requests.Cluster do
 
   def get_info(from) do
     NodeInfo.get_node_info() |> reply_to_core(from)
+  end
+
+  def store_function(%FunctionStruct{} = f, from) do
+    StoreResource.store_function(f) |> reply_to_core(from)
   end
 
   # reply should be either {:ok, result} or {:error, reason}

--- a/worker/lib/worker/adapters/requests/cluster/server.ex
+++ b/worker/lib/worker/adapters/requests/cluster/server.ex
@@ -78,5 +78,6 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
       ) do
     Logger.info("Received store function request for function #{mod}/#{fun}")
     spawn(Cluster, :store_function, [f, from])
+    {:noreply, nil}
   end
 end

--- a/worker/lib/worker/adapters/requests/cluster/server.ex
+++ b/worker/lib/worker/adapters/requests/cluster/server.ex
@@ -19,6 +19,7 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
     All calls return immediately without replying, delegating the required work to Requests.Cluster functions.
   """
   use GenServer, restart: :permanent
+  alias Data.FunctionStruct
   alias Worker.Adapters.Requests.Cluster
 
   require Logger
@@ -67,5 +68,15 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
     Logger.info("Received get info request.")
     spawn(Cluster, :get_info, [from])
     {:noreply, nil}
+  end
+
+  @impl true
+  def handle_call(
+        {:store_function, %FunctionStruct{name: fun, module: mod, code: _} = f},
+        from,
+        _state
+      ) do
+    Logger.info("Received store function request for function #{mod}/#{fun}")
+    spawn(Cluster, :store_function, [f, from])
   end
 end

--- a/worker/lib/worker/adapters/resource_cache/resource_cache.ex
+++ b/worker/lib/worker/adapters/resource_cache/resource_cache.ex
@@ -28,7 +28,7 @@ defmodule Worker.Adapters.ResourceCache do
   @resource_cache_table :resource_cache
 
   @doc """
-  Retrieve a resource from the cache, associated to a function name and a module.
+  Retrieve a resource from the cache, associated with a function name and a module.
 
   ## Parameters
   - `function_name`: the name of the function
@@ -47,7 +47,7 @@ defmodule Worker.Adapters.ResourceCache do
   end
 
   @doc """
-  Store a resource in the cache, associated to a function name and a module.
+  Store a resource in the cache, associated with a function name and a module.
 
   ## Parameters
   - `function_name`: the name of the function
@@ -63,7 +63,7 @@ defmodule Worker.Adapters.ResourceCache do
   end
 
   @doc """
-  Remove a resource from the cache, associated to a function name and a module.
+  Remove a resource from the cache, associated with a function name and a module.
 
   ## Parameters
   - `function_name`: the name of the function

--- a/worker/lib/worker/application.ex
+++ b/worker/lib/worker/application.ex
@@ -24,6 +24,7 @@ defmodule Worker.Application do
 
     children = [
       {Worker.Domain.Ports.NodeInfoStorage.Supervisor, []},
+      {Registry, keys: :unique, name: Worker.Adapters.RawResourceStorage.Registry},
       Worker.PromEx,
       {Cluster.Supervisor, [topologies, [name: Worker.ClusterSupervisor]]},
       {Adapters.Requests.Cluster.Server, []},

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -70,6 +70,7 @@ defmodule Worker.Domain.InvokeFunction do
         {:error, :code_not_found, pid}
 
       raw_resource ->
+        Logger.info("API: Raw resource found locally, provisioning...")
         f = f |> Map.put(:code, raw_resource)
         {:ok, resource} = ProvisionResource.provision(f)
         Runner.run_function(f, args, resource)

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -17,6 +17,7 @@ defmodule Worker.Domain.InvokeFunction do
   Contains functions used to run function runtimes. Side effects (e.g. docker interaction) are delegated to ports and adapters.
   """
 
+  alias Worker.Domain.Ports.RawResourceStorage
   alias Worker.Domain.Ports.Runtime.Runner
   alias Worker.Domain.Ports.WaitForCode
   alias Worker.Domain.ProvisionResource
@@ -51,8 +52,7 @@ defmodule Worker.Domain.InvokeFunction do
         Runner.run_function(function, args, resource)
 
       {:error, :code_not_found} ->
-        {:ok, pid} = WaitForCode.wait_for_code(args)
-        {:error, :code_not_found, pid}
+        invoke_no_code(f, args)
 
       {:error, err} ->
         {:error, err}
@@ -60,4 +60,19 @@ defmodule Worker.Domain.InvokeFunction do
   end
 
   def invoke(_, _), do: {:error, :bad_params}
+
+  @spec invoke_no_code(Data.FunctionStruct.t(), map()) ::
+          {:error, any()} | {:ok, any()} | {:error, :code_not_found, pid()}
+  def invoke_no_code(%FunctionStruct{name: name, module: mod} = f, args) do
+    case RawResourceStorage.get(name, mod) do
+      :resource_not_found ->
+        {:ok, pid} = WaitForCode.wait_for_code(args)
+        {:error, :code_not_found, pid}
+
+      raw_resource ->
+        f = f |> Map.put(:code, raw_resource)
+        {:ok, resource} = ProvisionResource.provision(f)
+        Runner.run_function(f, args, resource)
+    end
+  end
 end

--- a/worker/lib/worker/domain/ports/node_info_storage/node_info_storage.ex
+++ b/worker/lib/worker/domain/ports/node_info_storage/node_info_storage.ex
@@ -24,7 +24,7 @@ defmodule Worker.Domain.Ports.NodeInfoStorage do
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @doc """
-  Retrieve the value associated to the given key.
+  Retrieve the value associated with the given key.
 
   ### Parameters
   - `key` - Identifier (e.g. long_name, tag).
@@ -38,7 +38,7 @@ defmodule Worker.Domain.Ports.NodeInfoStorage do
   defdelegate get(key), to: @adapter
 
   @doc """
-  Insert a new value associated to the given key.
+  Insert a new value associated with the given key.
 
   ### Parameters
   - `key` - Identifier (e.g. long_name, tag). Must be a string.
@@ -53,7 +53,7 @@ defmodule Worker.Domain.Ports.NodeInfoStorage do
   defdelegate insert(key, value), to: @adapter
 
   @doc """
-  Update the value associated to the given (existing) key.
+  Update the value associated with the given (existing) key.
 
   ### Parameters
   - `key` - Identifier (e.g. long_name, tag). Must be a string.

--- a/worker/lib/worker/domain/ports/raw_resource_storage.ex
+++ b/worker/lib/worker/domain/ports/raw_resource_storage.ex
@@ -1,0 +1,69 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Domain.Ports.RawResourceStorage do
+  @moduledoc """
+  Port for storing raw binaries of resources associated with a function, module tuple.
+  For storage of initialized/compiled resources, see ResourceCache.
+  """
+
+  @callback get(String.t(), String.t()) :: binary() | :resource_not_found
+  @callback insert(String.t(), String.t(), binary()) :: :ok | {:error, any}
+  @callback delete(String.t(), String.t()) :: :ok | {:error, any}
+
+  @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+
+  @doc """
+  Retrieve the resource associated with the given function name and module.
+
+  ### Parameters
+  - `function_name` - The name of the function.
+  - `module` - The module of the function.
+
+  ### Returns
+  - `binary()` - The raw resource associated with the function.
+  - `:resource_not_found` - If the resource is not found.
+  """
+  @spec get(String.t(), String.t()) :: binary() | :resource_not_found
+  defdelegate get(function_name, module), to: @adapter
+
+  @doc """
+  Inserts a resource into the ResourceCache associated with a function.
+
+  ### Parameters
+  - `function_name` - The name of the function to associate the resource with.
+  - `module` - The module of the function.
+  - `resource` - The raw resource (i.e. binary) of the function to be inserted.
+
+  ### Returns
+  - `:ok` - If the resource was inserted.
+  - `{:error, err}` - If an error occurred and the resource could not be inserted.
+  """
+  @spec insert(String.t(), String.t(), binary()) :: :ok | {:error, any}
+  defdelegate insert(function_name, module, resource), to: @adapter
+
+  @doc """
+  Removes the raw resource associated with a function from the storage.
+
+  ### Parameters
+  - `function_name` - The name of the function that the resource is associated with.
+  - `module` - The module of the function.
+
+  ### Returns
+  - `:ok` - If the resource was removed.
+  - `{:error, err}` - If an error occurred and the resource could not be removed.
+  """
+  @spec delete(String.t(), String.t()) :: :ok | {:error, any}
+  defdelegate delete(function_name, module), to: @adapter
+end

--- a/worker/lib/worker/domain/ports/resource_cache.ex
+++ b/worker/lib/worker/domain/ports/resource_cache.ex
@@ -25,7 +25,7 @@ defmodule Worker.Domain.Ports.ResourceCache do
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @doc """
-  Retrieve the resource associated to the given function name and module.
+  Retrieve the resource associated with the given function name and module.
 
   ### Parameters
   - `function_name` - The name of the function.
@@ -39,10 +39,10 @@ defmodule Worker.Domain.Ports.ResourceCache do
   defdelegate get(function_name, module), to: @adapter
 
   @doc """
-  Inserts a resource into the ResourceCache associated to a function.
+  Inserts a resource into the ResourceCache associated with a function.
 
   ### Parameters
-  - `function_name` - The name of the function to associate the runtime with.
+  - `function_name` - The name of the function to associate the resource with.
   - `module` - The module of the function.
   - `resource` - The ExecutionResource of the function to be inserted.
 
@@ -51,13 +51,13 @@ defmodule Worker.Domain.Ports.ResourceCache do
   - `{:error, err}` - If an error occurred and the resource could not be inserted.
   """
   @spec insert(String.t(), String.t(), ExecutionResource.t()) :: :ok | {:error, any}
-  defdelegate insert(function_name, module, runtime), to: @adapter
+  defdelegate insert(function_name, module, resource), to: @adapter
 
   @doc """
   Removes the resource associated with a function from the ResourceCache.
 
   ### Parameters
-  - `function_name` - The name of the function that the runtime is associated with.
+  - `function_name` - The name of the function that the resource is associated with.
   - `module` - The module of the function.
 
   ### Returns

--- a/worker/lib/worker/domain/ports/runtime/cleaner.ex
+++ b/worker/lib/worker/domain/ports/runtime/cleaner.ex
@@ -14,7 +14,7 @@
 
 defmodule Worker.Domain.Ports.Runtime.Cleaner do
   @moduledoc """
-  Port for runtime removal.
+  Port for ExecutionResource removal.
   """
   alias Data.ExecutionResource
 
@@ -23,7 +23,7 @@ defmodule Worker.Domain.Ports.Runtime.Cleaner do
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @doc """
-  Cleans up the resources from the host system associated to a particular function.
+  Cleans up the resources from the host system associated with a particular function.
 
   ### Parameters
   - `resource` - The ExecutionResource.t() to be removed.

--- a/worker/lib/worker/domain/ports/runtime/provisioner.ex
+++ b/worker/lib/worker/domain/ports/runtime/provisioner.ex
@@ -14,7 +14,7 @@
 
 defmodule Worker.Domain.Ports.Runtime.Provisioner do
   @moduledoc """
-  Port for runtime creation.
+  Port for ExecutionResource creation.
   """
 
   alias Data.ExecutionResource
@@ -25,16 +25,16 @@ defmodule Worker.Domain.Ports.Runtime.Provisioner do
   @callback provision(FunctionStruct.t()) :: {:ok, ExecutionResource.t()} | {:error, any()}
 
   @doc """
-  Provisions a runtime for the given function and module.
-  It first tries to retrieve it from the cache, if missing it can either create a new one or return :runtime_not_found,
+  Provisions an ExecutionResource for the given function and module.
+  It first tries to retrieve it from the cache, if missing it can either create a new one or return :code_not_found,
   depending on the adapter.
 
   ## Parameters
   - function: a struct with all the fields required by Data.FunctionStruct
 
   ## Returns
-  - `{:ok, runtime}` if the runtime is found or created.any()
-  - `{:error, :runtime_not_found} if the runtime was not in the cache and it won't attempt to create one.
+  - `{:ok, resource}` if the resource is found or created
+  - `{:error, :code_not_found} if the resource was not in the cache and it won't attempt to create one.
   - `{:error, err}` if any error is encountered
   """
   @spec provision(FunctionStruct.t()) :: {:ok, ExecutionResource.t()} | {:error, any()}

--- a/worker/lib/worker/domain/provision_resource.ex
+++ b/worker/lib/worker/domain/provision_resource.ex
@@ -61,7 +61,7 @@ defmodule Worker.Domain.ProvisionResource do
   @spec cache_resource({:ok, ExecutionResource.t()} | {:error, any()}, String.t(), String.t()) ::
           {:ok, ExecutionResource.t()} | {:error, any}
   defp cache_resource({:error, :code_not_found}, _, _) do
-    Logger.warn("API: requesting resource from core...")
+    Logger.warn("API: resource not found...")
     {:error, :code_not_found}
   end
 

--- a/worker/lib/worker/domain/store_resources.ex
+++ b/worker/lib/worker/domain/store_resources.ex
@@ -1,0 +1,42 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Worker.Domain.StoreResource do
+  @moduledoc """
+  Contains functions used to store function resources on the worker.
+  This should be used for raw resources. If handling initialized/compiled resources, see Worker.Domain.ProvisionResource.
+  """
+  alias Data.FunctionStruct
+  alias Worker.Domain.Ports.RawResourceStorage
+
+  @doc """
+    Stores the given function's code as-is.
+
+    ## Parameters
+      - `%{...}`: Data.FunctionStruct, including at least the function's name, module and code
+
+    ## Returns
+      - `:ok` if the resource was inserted successfully
+      - `{:error, :invalid_input}` if some fields were missing, or the wrong struct was sent
+      - `{:error, err}` if any other error occurred during insertion
+  """
+  @spec store_function(FunctionStruct.t()) :: :ok | {:error, :invalid_input} | {:error, any()}
+  def store_function(%FunctionStruct{name: name, module: module, code: code}) do
+    RawResourceStorage.insert(name, module, code)
+  end
+
+  def store_function(_) do
+    {:error, :invalid_input}
+  end
+end


### PR DESCRIPTION
This PR optimizes scheduling and function invocation to reduce cold starts and handle potential high-latency in the underlying network.

Specifically:

- [x] Invocation timeout is increased from 30s to 60s
- [x] Default scheduling now selects the node with the most available memory (as opposed to least used)
- [x] Function code is sent at creation time, instead of invocation
- [x] Function code is saved on disk unless compiled (to avoid wasting memory at creation time for inactive functions)
- ~If the function's code is being compiled/sent, invocations wait for it to complete (instead of asking for the code multiple times)~ (moved to a future PR)