### PR TITLE
Handle function deletion in workers

### DIFF
--- a/core/lib/core/adapters/commands/test.ex
+++ b/core/lib/core/adapters/commands/test.ex
@@ -42,14 +42,4 @@ defmodule Core.Adapters.Commands.Test do
   def send_update_function(_worker, _prev_hash, _func) do
     :ok
   end
-
-  @impl true
-  def send_to_multiple_workers(_workers, _func, _args) do
-    :ok
-  end
-
-  @impl true
-  def send_to_multiple_workers_sync(_workers, _func, _args) do
-    []
-  end
 end

--- a/core/lib/core/adapters/commands/test.ex
+++ b/core/lib/core/adapters/commands/test.ex
@@ -19,7 +19,7 @@ defmodule Core.Adapters.Commands.Test do
   alias Data.InvokeResult
 
   @impl true
-  def send_invoke(_worker, name, _ns, _args) do
+  def send_invoke(_worker, name, _ns, _hash, _args) do
     {:ok, %InvokeResult{result: name}}
   end
 
@@ -31,5 +31,25 @@ defmodule Core.Adapters.Commands.Test do
   @impl true
   def send_store_function(_worker, _func) do
     :ok
+  end
+
+  @impl true
+  def send_delete_function(_worker, _func, _mod, _hash) do
+    :ok
+  end
+
+  @impl true
+  def send_update_function(_worker, _prev_hash, _func) do
+    :ok
+  end
+
+  @impl true
+  def send_to_multiple_workers(_workers, _func, _args) do
+    :ok
+  end
+
+  @impl true
+  def send_to_multiple_workers_sync(_workers, _func, _args) do
+    []
   end
 end

--- a/core/lib/core/adapters/commands/worker.ex
+++ b/core/lib/core/adapters/commands/worker.ex
@@ -90,19 +90,4 @@ defmodule Core.Adapters.Commands.Worker do
 
     GenServer.call(worker_addr, cmd, 60_000)
   end
-
-  @impl true
-  def send_to_multiple_workers(workers, command, args) do
-    Logger.info("Sending command multiple workers")
-    stream = Task.async_stream(workers, fn wrk -> apply(command, [wrk | args]) end)
-    Process.spawn(fn -> Stream.run(stream) end, [])
-    :ok
-  end
-
-  @impl true
-  def send_to_multiple_workers_sync(workers, command, args) do
-    Logger.info("Sending command multiple workers and waiting for response")
-    stream = Task.async_stream(workers, fn wrk -> apply(command, [wrk | args]) end)
-    Enum.reduce(stream, [], fn response, acc -> [response | acc] end)
-  end
 end

--- a/core/lib/core/domain/functions.ex
+++ b/core/lib/core/domain/functions.ex
@@ -82,7 +82,7 @@ defmodule Core.Domain.Functions do
         join: m in Module,
         on: f.module_id == m.id,
         where: m.name == ^mod_name and f.name == ^fun_name,
-        select: %Function{id: f.id, name: f.name, module_id: f.module_id}
+        select: %Function{id: f.id, name: f.name, module_id: f.module_id, hash: f.hash}
       )
 
     Repo.all(q)
@@ -107,7 +107,7 @@ defmodule Core.Domain.Functions do
         join: m in Module,
         on: f.module_id == m.id,
         where: m.name == ^mod_name and f.name == ^fun_name,
-        select: %Function{code: f.code}
+        select: %Function{code: f.code, hash: f.hash}
       )
 
     Repo.all(q)

--- a/core/lib/core/schemas/function.ex
+++ b/core/lib/core/schemas/function.ex
@@ -22,6 +22,7 @@ defmodule Core.Schemas.Function do
   schema "functions" do
     field(:code, :binary)
     field(:name, :string)
+    field(:hash, :binary)
 
     timestamps()
 
@@ -39,7 +40,22 @@ defmodule Core.Schemas.Function do
     |> validate_required([:name, :code, :module_id])
     |> validate_format(:name, regex, message: msg)
     |> validate_length(:name, min: 1, max: 160)
+    |> insert_hash()
     |> unique_constraint(:function_module_index_constraint, name: :function_module_index)
     |> foreign_key_constraint(:module_id)
+  end
+
+  defp insert_hash(changeset) do
+    case changeset do
+      %Ecto.Changeset{valid?: true, changes: %{code: code}} ->
+        put_change(changeset, :hash, create_hash(code))
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp create_hash(code) do
+    :crypto.hash(:sha3_256, code)
   end
 end

--- a/core/priv/repo/migrations/20240207144706_add_functions_code_hash.exs
+++ b/core/priv/repo/migrations/20240207144706_add_functions_code_hash.exs
@@ -1,0 +1,23 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Repo.Migrations.AddFunctionsCodeHash do
+  use Ecto.Migration
+
+  def change do
+    alter table(:functions) do
+      add :hash, :binary
+    end
+  end
+end

--- a/core/rel/env.sh.eex
+++ b/core/rel/env.sh.eex
@@ -33,5 +33,5 @@ MACHINE_ADDR=$(ip -f inet addr show $MACHINE_INTERFACE | sed -En 's/.*inet ([0-9
 # Set the release to work across nodes.
 # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@$MACHINE_ADDR
+export RELEASE_NODE=<%= @release.name %>@${NODE_IP:-$MACHINE_ADDR}
 export RELEASE_COOKIE="default_secret"

--- a/core/test/core/integration/invoke_test.exs
+++ b/core/test/core/integration/invoke_test.exs
@@ -84,7 +84,7 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
 
       pars = %InvokeParams{function: function.name, module: module.name}
       assert Invoker.invoke(pars) == {:error, {:exec_error, "some error"}}
@@ -98,7 +98,7 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:error, {:exec_error, "some error"}} end)
 
       {:ok, resources} = Core.Telemetry.Metrics.Mock.resources(:worker@localhost)
       concurrent = resources |> Map.get(:concurrent_functions, 0)
@@ -132,7 +132,9 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:core@somewhere, :worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn worker, _, _, _ -> {:ok, %InvokeResult{result: worker}} end)
+      |> Mox.expect(:send_invoke, fn worker, _, _, _, _ ->
+        {:ok, %InvokeResult{result: worker}}
+      end)
 
       pars = %InvokeParams{function: function.name, module: module.name}
       assert Invoker.invoke(pars) == {:ok, :worker@localhost}
@@ -164,7 +166,7 @@ defmodule Core.InvokeTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, self()} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:error, :code_not_found, self()} end)
 
       Core.Commands.Mock
       |> Mox.expect(:send_invoke_with_code, fn _worker, _handler, function ->
@@ -175,6 +177,7 @@ defmodule Core.InvokeTest do
         name: function.name,
         module: module.name,
         code: function.code,
+        hash: function.hash,
         metadata: struct(FunctionMetadata, %{})
       }
 

--- a/core/test/core/unit/policies/app_policy_test.exs
+++ b/core/test/core/unit/policies/app_policy_test.exs
@@ -64,6 +64,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128
         }
@@ -93,6 +94,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128
         }
@@ -122,6 +124,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128
         }
@@ -151,6 +154,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128
         }
@@ -239,6 +243,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128,
           tag: "test-tag"
@@ -310,6 +315,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           tag: "non-existent-tag",
           capacity: 128
@@ -495,6 +501,7 @@ defmodule Core.Unit.Policies.AppPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           tag: "non-existent-tag",
           capacity: 128
@@ -508,7 +515,8 @@ defmodule Core.Unit.Policies.AppPolicyTest do
          %{impl: app_impl, workers: workers, script: script} do
       function = %FunctionStruct{
         name: "test-func",
-        module: "test-mod"
+        module: "test-mod",
+        hash: <<0, 0, 0>>
       }
 
       assert app_impl.select(script, workers, function) ==

--- a/core/test/core/unit/policies/default_policy_test.exs
+++ b/core/test/core/unit/policies/default_policy_test.exs
@@ -68,6 +68,7 @@ defmodule Core.Unit.Policies.DefaultPolicyTest do
       function = %FunctionStruct{
         name: "test-func",
         module: "test-mod",
+        hash: <<0, 0, 0>>,
         metadata: %FunctionMetadata{
           capacity: 128
         }
@@ -116,7 +117,8 @@ defmodule Core.Unit.Policies.DefaultPolicyTest do
          %{impl: def_impl, workers: workers} do
       function = %FunctionStruct{
         name: "test-func",
-        module: "test-mod"
+        module: "test-mod",
+        hash: <<0, 0, 0>>
       }
 
       assert def_impl.select(%Empty{}, workers, function) ==

--- a/core/test/core_web/integration/controllers/function_controller_test.exs
+++ b/core/test/core_web/integration/controllers/function_controller_test.exs
@@ -438,7 +438,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:ok, %{result: "Hello, World!"}} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:ok, %{result: "Hello, World!"}} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}")
       assert response(conn, 200)
@@ -452,7 +452,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:ok, %{result: "Hello, World!"}} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:ok, %{result: "Hello, World!"}} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}", args: %{name: "World"})
 
@@ -467,7 +467,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, :code_not_found, self()} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:error, :code_not_found, self()} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}")
       assert response(conn, 200)
@@ -504,7 +504,7 @@ defmodule CoreWeb.FunctionControllerTest do
       Core.Cluster.Mock |> Mox.expect(:all_nodes, fn -> [:worker@localhost] end)
 
       Core.Commands.Mock
-      |> Mox.expect(:send_invoke, fn _, _, _, _ -> {:error, {:exec_error, "some reason"}} end)
+      |> Mox.expect(:send_invoke, fn _, _, _, _, _ -> {:error, {:exec_error, "some reason"}} end)
 
       conn = post(conn, ~p"/v1/fn/#{module_name}/#{function_name}")
       assert response(conn, 422)

--- a/data/lib/function.ex
+++ b/data/lib/function.ex
@@ -31,6 +31,6 @@ defmodule Data.FunctionStruct do
           hash: binary(),
           metadata: Data.FunctionMetadata.t()
         }
-  @enforce_keys [:name, :module]
+  @enforce_keys [:name, :module, :hash]
   defstruct [:name, :module, :code, :hash, :metadata]
 end

--- a/data/lib/function.ex
+++ b/data/lib/function.ex
@@ -21,14 +21,16 @@ defmodule Data.FunctionStruct do
       - name: function name
       - module: function module
       - code: function code binary
+      - hash: sha3-256 hash of the function code binary
       - metadata: additional information about the function
   """
   @type t :: %__MODULE__{
           module: String.t(),
           name: String.t(),
           code: binary(),
+          hash: binary(),
           metadata: Data.FunctionMetadata.t()
         }
   @enforce_keys [:name, :module]
-  defstruct [:name, :module, :code, :metadata]
+  defstruct [:name, :module, :code, :hash, :metadata]
 end

--- a/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/raw_resource_storage.ex
@@ -26,34 +26,35 @@ defmodule Worker.Adapters.RawResourceStorage do
 
   @doc """
 
-  Gets the saved raw resource, if available.
+  Gets the saved raw resource, if available and if it matches the given hash.
   In case a process is already writing/deleting it, it waits for it to complete.
 
   ## Parameters
   - `function_name`: the name of the function
   - `module`: the module of the function
+  - `hash`: an hash code which identifies the function
 
   ## Returns
   - `resource` if the resource is found;
   - `:resource_not_found` if the resource is not found.
   """
   @impl true
-  def get(function_name, module) do
+  def get(function_name, module, hash) do
     process_name = @process_prefix <> "#{module}_#{function_name}"
 
     case Registry.lookup(@registry, process_name) do
       [] ->
-        do_get(function_name, module)
+        do_get(function_name, module, hash)
 
       [{pid, _} | _] ->
         ref = Process.monitor(pid)
 
         receive do
           {:DOWN, ^ref, _, _, :normal} ->
-            do_get(function_name, module)
+            do_get(function_name, module, hash)
 
           {:DOWN, ^ref, _, _, :noproc} ->
-            do_get(function_name, module)
+            do_get(function_name, module, hash)
 
           {:DOWN, ^ref, _, _, {:error, _}} ->
             :resource_not_found
@@ -64,11 +65,18 @@ defmodule Worker.Adapters.RawResourceStorage do
     end
   end
 
-  defp do_get(function_name, module) do
+  defp do_get(function_name, module, hash) do
     file_path = get_file_path(function_name, module)
+    hash_path = get_hash_path(function_name, module)
 
-    case File.read(file_path) do
-      {:ok, resource} -> resource
+    with {:ok, resource} <- File.read(file_path),
+         {:ok, resource_hash} <- File.read(hash_path) do
+      if resource_hash == hash do
+        resource
+      else
+        :resource_not_found
+      end
+    else
       {:error, _} -> :resource_not_found
     end
   end
@@ -78,12 +86,14 @@ defmodule Worker.Adapters.RawResourceStorage do
   It spawns and registers a process to perform the file creation, using Worker.Adapters.RawResourceStorage.Registry.
   The process is monitored as soon as it is spawned.
   In case a process is already writing/deleting the same file, it monitors that instead.
+  The process also saves a hash file, to identify the function in subsequent `get`/`delete` requests.
 
   If the file was being deleted, this function returns `:ok` if the deletion completes successfully.
 
   ## Parameters
   - `function_name`: the name of the function
   - `module`: the module of the function
+  - `hash`: an hash code which identifies the function
   - `resource`: the resource to store
 
   ## Returns
@@ -91,7 +101,7 @@ defmodule Worker.Adapters.RawResourceStorage do
   - `{:error, err}` if any error arose during the registration of the process, or the creation of the file
   """
   @impl true
-  def insert(function_name, module, resource) do
+  def insert(function_name, module, hash, resource) do
     process_name = @process_prefix <> "#{module}_#{function_name}"
 
     insert_ref =
@@ -105,6 +115,7 @@ defmodule Worker.Adapters.RawResourceStorage do
                 process_name,
                 function_name,
                 module,
+                hash,
                 resource
               ],
               [:monitor]
@@ -131,33 +142,32 @@ defmodule Worker.Adapters.RawResourceStorage do
     end
   end
 
-  @spec do_insert(String.t(), String.t(), String.t(), binary()) :: :ok | {:error, any()}
-  def do_insert(process_name, function_name, module, resource) do
-    case Registry.register(@registry, process_name, nil) do
-      {:ok, _} ->
-        file_path = get_file_path(function_name, module)
-
-        result =
-          if File.exists?(file_path) do
-            # nothing to do (in the future we should update)
-            :ok
-          else
-            File.write(file_path, resource)
-          end
-
-        case result do
-          :ok -> :ok
-          {:error, err} -> exit({:error, err})
-        end
-
+  @spec do_insert(String.t(), String.t(), String.t(), binary(), binary()) :: :ok | {:error, any()}
+  def do_insert(process_name, function_name, module, hash, resource) do
+    with {:ok, _} <- Registry.register(@registry, process_name, nil),
+         file_path <- get_file_path(function_name, module),
+         hash_path <- get_hash_path(function_name, module),
+         :ok <- check_and_save(file_path, resource),
+         :ok <- check_and_save(hash_path, hash) do
+      :ok
+    else
       {:error, err} ->
         exit({:error, err})
     end
   end
 
+  defp check_and_save(path, content) do
+    if File.exists?(path) do
+      # nothing to do (in the future we should update)
+      :ok
+    else
+      File.write(path, content)
+    end
+  end
+
   @doc """
 
-  Deletes a raw resource, if it exists.
+  Deletes a raw resource, if it exists and it matches the given hash.
   It spawns and registers a process to perform the file deletion, using Worker.Adapters.RawResourceStorage.Registry.
   The process is monitored as soon as it is spawned.
   In case a process is already writing/deleting the same file, it monitors that instead.
@@ -167,13 +177,14 @@ defmodule Worker.Adapters.RawResourceStorage do
   ## Parameters
   - `function_name`: the name of the function
   - `module`: the module of the function
+  - `hash`: an hash code which identifies the function
 
   ## Returns
   - `:ok` if everything went well
   - `{:error, err}` if any error arose during the registration of the process, or the deletion of the file
   """
   @impl true
-  def delete(function_name, module) do
+  def delete(function_name, module, hash) do
     process_name = @process_prefix <> "#{module}_#{function_name}"
 
     delete_ref =
@@ -186,7 +197,8 @@ defmodule Worker.Adapters.RawResourceStorage do
               [
                 process_name,
                 function_name,
-                module
+                module,
+                hash
               ],
               [:monitor]
             )
@@ -212,24 +224,37 @@ defmodule Worker.Adapters.RawResourceStorage do
     end
   end
 
-  @spec do_delete(String.t(), String.t(), String.t()) :: :ok | {:error, any()}
-  def do_delete(process_name, function_name, module) do
-    case Registry.register(@registry, process_name, nil) do
-      {:ok, _} ->
-        file_path = get_file_path(function_name, module)
-
-        case File.rm(file_path) do
-          :ok -> :ok
-          {:error, :enoent} -> :ok
-          {:error, err} -> exit({:error, err})
-        end
-
+  @spec do_delete(String.t(), String.t(), String.t(), binary()) :: :ok | {:error, any()}
+  def do_delete(process_name, function_name, module, hash) do
+    with {:ok, _} <- Registry.register(@registry, process_name, nil),
+         file_path <- get_file_path(function_name, module),
+         hash_path <- get_hash_path(function_name, module),
+         {:ok, resource_hash} <- File.read(hash_path),
+         :ok <- check_and_delete(file_path, resource_hash, hash) do
+      :ok
+    else
       {:error, err} ->
         exit({:error, err})
     end
   end
 
+  defp check_and_delete(path, saved_hash, hash) do
+    if saved_hash == hash do
+      case File.rm(path) do
+        :ok -> :ok
+        {:error, :enoent} -> :ok
+        {:error, err} -> {:error, err}
+      end
+    else
+      :ok
+    end
+  end
+
   defp get_file_path(function_name, module) do
     Path.join([@file_prefix, "#{module}_#{function_name}"])
+  end
+
+  defp get_hash_path(function_name, module) do
+    Path.join([@file_prefix, "#{module}_#{function_name}.hash"])
   end
 end

--- a/worker/lib/worker/adapters/raw_resource_storage/test.ex
+++ b/worker/lib/worker/adapters/raw_resource_storage/test.ex
@@ -17,17 +17,17 @@ defmodule Worker.Adapters.RawResourceStorage.Test do
   @behaviour Worker.Domain.Ports.RawResourceStorage
 
   @impl true
-  def get(_name, _mod) do
+  def get(_name, _mod, _hash) do
     <<0>>
   end
 
   @impl true
-  def insert(_name, _mod, _resource) do
+  def insert(_name, _mod, _hash, _resource) do
     :ok
   end
 
   @impl true
-  def delete(_name, _mod) do
+  def delete(_name, _mod, _hash) do
     :ok
   end
 end

--- a/worker/lib/worker/adapters/requests/cluster/cluster.ex
+++ b/worker/lib/worker/adapters/requests/cluster/cluster.ex
@@ -16,12 +16,12 @@ defmodule Worker.Adapters.Requests.Cluster do
   @moduledoc """
   Contains functions exposing the Worker API to other processes/nodes in the cluster.
   """
-  alias Worker.Adapters.RawResourceStorage
-  alias Worker.Domain.ProvisionResource
-  alias Worker.Domain.CleanupResource
   alias Data.FunctionStruct
+  alias Worker.Adapters.RawResourceStorage
+  alias Worker.Domain.CleanupResource
   alias Worker.Domain.InvokeFunction
   alias Worker.Domain.NodeInfo
+  alias Worker.Domain.ProvisionResource
   alias Worker.Domain.StoreResource
 
   require Logger
@@ -81,9 +81,8 @@ defmodule Worker.Adapters.Requests.Cluster do
          :ok,
          %FunctionStruct{name: fun, module: mod, code: code, hash: hash} = function
        ) do
-    with {:ok, _} <- ProvisionResource.provision(function),
-         :ok <- RawResourceStorage.insert(fun, mod, hash, code) do
-      :ok
+    with {:ok, _} <- ProvisionResource.provision(function) do
+      RawResourceStorage.insert(fun, mod, hash, code)
     end
   end
 

--- a/worker/lib/worker/adapters/requests/cluster/server.ex
+++ b/worker/lib/worker/adapters/requests/cluster/server.ex
@@ -72,12 +72,30 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
 
   @impl true
   def handle_call(
-        {:store_function, %FunctionStruct{name: fun, module: mod, code: _} = f},
+        {:store_function, %FunctionStruct{name: fun, module: mod, code: _, hash: _} = f},
         from,
         _state
       ) do
     Logger.info("Received store function request for function #{mod}/#{fun}")
     spawn(Cluster, :store_function, [f, from])
+    {:noreply, nil}
+  end
+
+  @impl true
+  def handle_call({:delete_function, name, module, hash}, from, _state) do
+    Logger.info("Received delete function request for function #{module}/#{name}")
+    spawn(Cluster, :delete_function, [name, module, hash, from])
+    {:noreply, nil}
+  end
+
+  def handle_call(
+        {:update_function, prev_hash,
+         %FunctionStruct{name: fun, module: mod, code: _, hash: _} = f},
+        from,
+        _state
+      ) do
+    Logger.info("Received update function request for function #{mod}/#{fun}")
+    spawn(Cluster, :update_function, [prev_hash, f, from])
     {:noreply, nil}
   end
 end

--- a/worker/lib/worker/adapters/resource_cache/test.ex
+++ b/worker/lib/worker/adapters/resource_cache/test.ex
@@ -18,17 +18,17 @@ defmodule Worker.Adapters.ResourceCache.Test do
   alias Data.ExecutionResource
 
   @impl true
-  def get(_function_name, _module) do
+  def get(_function_name, _module, _hash) do
     %ExecutionResource{resource: "runtime"}
   end
 
   @impl true
-  def insert(_name, _ns, _runtime) do
+  def insert(_name, _ns, _hash, _runtime) do
     :ok
   end
 
   @impl true
-  def delete(_name, _ns) do
+  def delete(_name, _ns, _hash) do
     :ok
   end
 end

--- a/worker/lib/worker/domain/cleanup_resource.ex
+++ b/worker/lib/worker/domain/cleanup_resource.ex
@@ -16,8 +16,8 @@ defmodule Worker.Domain.CleanupResource do
   @moduledoc """
   Contains functions used to remove function runtimes. Side effects (e.g. docker interaction) are delegated to ports and adapters.
   """
-  alias Worker.Adapters.RawResourceStorage
   alias Data.FunctionStruct
+  alias Worker.Domain.Ports.RawResourceStorage
   alias Worker.Domain.Ports.ResourceCache
   alias Worker.Domain.Ports.Runtime.Cleaner
 

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -43,7 +43,7 @@ defmodule Worker.Domain.InvokeFunction do
 
   def invoke(%{__struct__: _s} = f, args), do: invoke(Map.from_struct(f), args)
 
-  def invoke(%{name: name, module: mod} = function, args) do
+  def invoke(%{name: name, module: mod, hash: _hash} = function, args) do
     f = struct(FunctionStruct, function)
     Logger.info("API: Invoking function #{mod}/#{name}")
 
@@ -63,8 +63,8 @@ defmodule Worker.Domain.InvokeFunction do
 
   @spec invoke_no_code(Data.FunctionStruct.t(), map()) ::
           {:error, any()} | {:ok, any()} | {:error, :code_not_found, pid()}
-  def invoke_no_code(%FunctionStruct{name: name, module: mod} = f, args) do
-    case RawResourceStorage.get(name, mod) do
+  def invoke_no_code(%FunctionStruct{name: name, module: mod, hash: hash} = f, args) do
+    case RawResourceStorage.get(name, mod, hash) do
       :resource_not_found ->
         {:ok, pid} = WaitForCode.wait_for_code(args)
         {:error, :code_not_found, pid}

--- a/worker/lib/worker/domain/node_info.ex
+++ b/worker/lib/worker/domain/node_info.ex
@@ -17,8 +17,6 @@ defmodule Worker.Domain.NodeInfo do
   """
   alias Worker.Domain.Ports.NodeInfoStorage
 
-  @node_info_event [:prom_ex, :plugin, :node_info, :labels]
-
   def update_node_info(name, nil) do
     with {:ok, tag} <- NodeInfoStorage.get("tag"),
          :ok <- NodeInfoStorage.update("long_name", name) do

--- a/worker/lib/worker/domain/ports/raw_resource_storage.ex
+++ b/worker/lib/worker/domain/ports/raw_resource_storage.ex
@@ -18,52 +18,56 @@ defmodule Worker.Domain.Ports.RawResourceStorage do
   For storage of initialized/compiled resources, see ResourceCache.
   """
 
-  @callback get(String.t(), String.t()) :: binary() | :resource_not_found
-  @callback insert(String.t(), String.t(), binary()) :: :ok | {:error, any}
-  @callback delete(String.t(), String.t()) :: :ok | {:error, any}
+  @callback get(String.t(), String.t(), binary()) :: binary() | :resource_not_found
+  @callback insert(String.t(), String.t(), binary(), binary()) :: :ok | {:error, any}
+  @callback delete(String.t(), String.t(), binary()) :: :ok | {:error, any}
 
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
   @doc """
-  Retrieve the resource associated with the given function name and module.
+  Retrieve the resource associated with the given function name and module, and having the given hash.
 
   ### Parameters
   - `function_name` - The name of the function.
   - `module` - The module of the function.
+  - `hash` - An hash identifying the resource.
 
   ### Returns
   - `binary()` - The raw resource associated with the function.
   - `:resource_not_found` - If the resource is not found.
   """
-  @spec get(String.t(), String.t()) :: binary() | :resource_not_found
-  defdelegate get(function_name, module), to: @adapter
+  @spec get(String.t(), String.t(), binary()) :: binary() | :resource_not_found
+  defdelegate get(function_name, module, hash), to: @adapter
 
   @doc """
-  Inserts a resource into the ResourceCache associated with a function.
+  Inserts a resource associated with a function into the RawResourceStorage.
+  Keeps track of the given resource hash.
 
   ### Parameters
   - `function_name` - The name of the function to associate the resource with.
   - `module` - The module of the function.
+  - `hash` - An hash identifying the resource.
   - `resource` - The raw resource (i.e. binary) of the function to be inserted.
 
   ### Returns
   - `:ok` - If the resource was inserted.
   - `{:error, err}` - If an error occurred and the resource could not be inserted.
   """
-  @spec insert(String.t(), String.t(), binary()) :: :ok | {:error, any}
-  defdelegate insert(function_name, module, resource), to: @adapter
+  @spec insert(String.t(), String.t(), binary(), binary()) :: :ok | {:error, any}
+  defdelegate insert(function_name, module, hash, resource), to: @adapter
 
   @doc """
-  Removes the raw resource associated with a function from the storage.
+  Removes the raw resource associated with a function from the storage, if the resource matches the given hash.
 
   ### Parameters
   - `function_name` - The name of the function that the resource is associated with.
   - `module` - The module of the function.
+  - `hash` - An hash identifying the resource.
 
   ### Returns
   - `:ok` - If the resource was removed.
   - `{:error, err}` - If an error occurred and the resource could not be removed.
   """
-  @spec delete(String.t(), String.t()) :: :ok | {:error, any}
-  defdelegate delete(function_name, module), to: @adapter
+  @spec delete(String.t(), String.t(), binary()) :: :ok | {:error, any}
+  defdelegate delete(function_name, module, hash), to: @adapter
 end

--- a/worker/lib/worker/domain/ports/raw_resource_storage.ex
+++ b/worker/lib/worker/domain/ports/raw_resource_storage.ex
@@ -68,6 +68,6 @@ defmodule Worker.Domain.Ports.RawResourceStorage do
   - `:ok` - If the resource was removed.
   - `{:error, err}` - If an error occurred and the resource could not be removed.
   """
-  @spec delete(String.t(), String.t(), binary()) :: :ok | {:error, any}
+  @spec delete(String.t(), String.t(), binary()) :: :ok | {:error, :enoent} | {:error, any}
   defdelegate delete(function_name, module, hash), to: @adapter
 end

--- a/worker/lib/worker/domain/ports/resource_cache.ex
+++ b/worker/lib/worker/domain/ports/resource_cache.ex
@@ -18,9 +18,9 @@ defmodule Worker.Domain.Ports.ResourceCache do
   """
   alias Data.ExecutionResource
 
-  @callback get(String.t(), String.t()) :: ExecutionResource.t() | :resource_not_found
-  @callback insert(String.t(), String.t(), ExecutionResource.t()) :: :ok | {:error, any}
-  @callback delete(String.t(), String.t()) :: :ok | {:error, any}
+  @callback get(String.t(), String.t(), binary()) :: ExecutionResource.t() | :resource_not_found
+  @callback insert(String.t(), String.t(), binary(), ExecutionResource.t()) :: :ok | {:error, any}
+  @callback delete(String.t(), String.t(), binary()) :: :ok | {:error, any}
 
   @adapter :worker |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
 
@@ -30,13 +30,14 @@ defmodule Worker.Domain.Ports.ResourceCache do
   ### Parameters
   - `function_name` - The name of the function.
   - `module` - The module of the function.
+  - `hash`: the hash of the non-compiled code of the function.
 
   ### Returns
   - `ExecutionResource.t()` - The resource of the given function name if found.
   - `:resource_not_found` - If the resource is not found.
   """
-  @spec get(String.t(), String.t()) :: ExecutionResource.t() | :resource_not_found
-  defdelegate get(function_name, module), to: @adapter
+  @spec get(String.t(), String.t(), binary()) :: ExecutionResource.t() | :resource_not_found
+  defdelegate get(function_name, module, hash), to: @adapter
 
   @doc """
   Inserts a resource into the ResourceCache associated with a function.
@@ -50,8 +51,8 @@ defmodule Worker.Domain.Ports.ResourceCache do
   - `:ok` - If the resource was inserted.
   - `{:error, err}` - If an error occurred and the resource could not be inserted.
   """
-  @spec insert(String.t(), String.t(), ExecutionResource.t()) :: :ok | {:error, any}
-  defdelegate insert(function_name, module, resource), to: @adapter
+  @spec insert(String.t(), String.t(), binary(), ExecutionResource.t()) :: :ok | {:error, any}
+  defdelegate insert(function_name, module, hash, resource), to: @adapter
 
   @doc """
   Removes the resource associated with a function from the ResourceCache.
@@ -64,6 +65,6 @@ defmodule Worker.Domain.Ports.ResourceCache do
   - `:ok` - If the resource was removed.
   - `{:error, err}` - If an error occurred and the resource could not be removed.
   """
-  @spec delete(String.t(), String.t()) :: :ok | {:error, any}
-  defdelegate delete(function_name, module), to: @adapter
+  @spec delete(String.t(), String.t(), binary()) :: :ok | {:error, any}
+  defdelegate delete(function_name, module, hash), to: @adapter
 end

--- a/worker/lib/worker/domain/store_resources.ex
+++ b/worker/lib/worker/domain/store_resources.ex
@@ -24,7 +24,7 @@ defmodule Worker.Domain.StoreResource do
     Stores the given function's code as-is.
 
     ## Parameters
-      - `%{...}`: Data.FunctionStruct, including at least the function's name, module and code
+      - `%{...}`: Data.FunctionStruct, including at least the function's name, module, hash and code
 
     ## Returns
       - `:ok` if the resource was inserted successfully
@@ -32,8 +32,8 @@ defmodule Worker.Domain.StoreResource do
       - `{:error, err}` if any other error occurred during insertion
   """
   @spec store_function(FunctionStruct.t()) :: :ok | {:error, :invalid_input} | {:error, any()}
-  def store_function(%FunctionStruct{name: name, module: module, code: code}) do
-    RawResourceStorage.insert(name, module, code)
+  def store_function(%FunctionStruct{name: name, module: module, code: code, hash: hash}) do
+    RawResourceStorage.insert(name, module, hash, code)
   end
 
   def store_function(_) do

--- a/worker/rel/env.sh.eex
+++ b/worker/rel/env.sh.eex
@@ -34,5 +34,5 @@ MACHINE_ADDR=$(ip -f inet addr show $MACHINE_INTERFACE | sed -En 's/.*inet ([0-9
 # Set the release to work across nodes.
 # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@$MACHINE_ADDR
+export RELEASE_NODE=<%= @release.name %>@${NODE_IP:-$MACHINE_ADDR}
 export RELEASE_COOKIE="default_secret"

--- a/worker/test/integration/adapters/requests_test.exs
+++ b/worker/test/integration/adapters/requests_test.exs
@@ -25,7 +25,8 @@ defmodule RequestTest do
     function = %{
       name: "hellojs",
       module: "_",
-      code: "code"
+      code: "code",
+      hash: <<0, 0, 0>>
     }
 
     %{function: function}
@@ -48,7 +49,7 @@ defmodule RequestTest do
       pid: pid,
       function: function
     } do
-      Worker.ResourceCache.Mock |> Mox.expect(:get, 1, fn _, _ -> :resource_not_found end)
+      Worker.ResourceCache.Mock |> Mox.expect(:get, 1, fn _, _, _ -> :resource_not_found end)
 
       Worker.Provisioner.Mock
       |> Mox.expect(:provision, &Worker.Adapters.Runtime.Provisioner.Test.provision/1)
@@ -85,11 +86,12 @@ defmodule RequestTest do
            pid: pid
          } do
       Worker.RawResourceStorage.Mock
-      |> Mox.expect(:insert, fn "fn", "mod", <<0, 0, 0>> -> :ok end)
+      |> Mox.expect(:insert, fn "fn", "mod", <<0, 0, 0>>, <<0, 0, 0>> -> :ok end)
 
       assert GenServer.call(
                pid,
-               {:store_function, %FunctionStruct{name: "fn", module: "mod", code: <<0, 0, 0>>}}
+               {:store_function,
+                %FunctionStruct{name: "fn", module: "mod", code: <<0, 0, 0>>, hash: <<0, 0, 0>>}}
              ) == :ok
     end
   end

--- a/worker/test/integration/adapters/resource_cache_test.exs
+++ b/worker/test/integration/adapters/resource_cache_test.exs
@@ -21,27 +21,30 @@ defmodule Integration.ResourceCacheTest do
   setup :verify_on_exit!
 
   test "get returns an empty :resource_not_found when no resource stored" do
-    result = ResourceCache.get("test-no-runtime", "fake-ns")
+    result = ResourceCache.get("test-no-runtime", "fake-ns", <<0, 0, 0>>)
     assert result == :resource_not_found
   end
 
   test "insert adds a {function_name, module} resource to the cache" do
     runtime = %ExecutionResource{resource: "runtime"}
+    hash = <<1, 1, 1>>
 
-    ResourceCache.insert("test", "ns", runtime)
-    assert ResourceCache.get("test", "ns") == runtime
-    ResourceCache.delete("test", "ns")
+    ResourceCache.insert("test", "ns", hash, runtime)
+    assert ResourceCache.get("test", "ns", hash) == runtime
+    ResourceCache.delete("test", "ns", hash)
   end
 
   test "delete removes a {function_name, ns} resource couple from the storage" do
     runtime = %ExecutionResource{resource: "runtime"}
-    ResourceCache.insert("test-delete", "ns", runtime)
-    ResourceCache.delete("test-delete", "ns")
-    assert ResourceCache.get("test-delete", "ns") == :resource_not_found
+    hash = <<1, 1, 1>>
+
+    ResourceCache.insert("test-delete", "ns", hash, runtime)
+    ResourceCache.delete("test-delete", "ns", hash)
+    assert ResourceCache.get("test-delete", "ns", hash) == :resource_not_found
   end
 
   test "delete on empty storage does nothing" do
-    result = ResourceCache.delete("test", "ns")
+    result = ResourceCache.delete("test", "ns", <<0, 0, 0>>)
     assert result == :ok
   end
 end

--- a/worker/test/integration/adapters/wasm_test.exs
+++ b/worker/test/integration/adapters/wasm_test.exs
@@ -27,10 +27,14 @@ defmodule Integration.Adapters.WasmTest do
       Worker.Provisioner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Wasm.Provisioner)
       Worker.ResourceCache.Mock |> Mox.stub_with(Worker.Adapters.ResourceCache)
 
+      code = File.read!("test/fixtures/not_impl.wasm")
+      hash = :crypto.hash(:sha3_256, code)
+
       function = %Data.FunctionStruct{
         name: "test-function",
         module: "test-module",
-        code: File.read!("test/fixtures/not_impl.wasm")
+        code: code,
+        hash: hash
       }
 
       {:ok, function: function}
@@ -64,22 +68,34 @@ defmodule Integration.Adapters.WasmTest do
       Worker.ResourceCache.Mock |> Mox.stub_with(Worker.Adapters.ResourceCache)
       Worker.Runner.Mock |> Mox.stub_with(Worker.Adapters.Runtime.Wasm.Runner)
 
+      code = File.read!("test/fixtures/not_impl.wasm")
+      hash = :crypto.hash(:sha3_256, code)
+
       err_function = %Data.FunctionStruct{
         name: "err_function",
         module: "testmodule",
-        code: File.read!("test/fixtures/not_impl.wasm")
+        code: code,
+        hash: hash
       }
+
+      code = File.read!("test/fixtures/hello_name.wasm")
+      hash = :crypto.hash(:sha3_256, code)
 
       hello_function = %Data.FunctionStruct{
         name: "hello_function",
         module: "testmodule",
-        code: File.read!("test/fixtures/hello_name.wasm")
+        code: code,
+        hash: hash
       }
+
+      code = File.read!("test/fixtures/rs_http.wasm")
+      hash = :crypto.hash(:sha3_256, code)
 
       http_function = %Data.FunctionStruct{
         name: "http_function",
         module: "testmodule",
-        code: File.read!("test/fixtures/rs_http.wasm")
+        code: code,
+        hash: hash
       }
 
       {:ok,

--- a/worker/test/unit/invoke_test.exs
+++ b/worker/test/unit/invoke_test.exs
@@ -24,7 +24,8 @@ defmodule InvokeTest do
     function = %{
       name: "test-ivk-fn",
       module: "_",
-      code: "code"
+      code: "code",
+      hash: <<0, 0, 0>>
     }
 
     %{function: function}
@@ -54,7 +55,7 @@ defmodule InvokeTest do
 
     test "should call provision when no resource for execution is found for the given function",
          %{function: function} do
-      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _ -> :resource_not_found end)
+      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _, _ -> :resource_not_found end)
       Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:ok, %{}} end)
 
       # Output from the test default
@@ -65,8 +66,8 @@ defmodule InvokeTest do
          %{function: function} do
       function = function |> Map.delete(:code)
 
-      Worker.ResourceCache.Mock |> Mox.expect(:get, 2, fn _, _ -> :resource_not_found end)
-      Worker.RawResourceStorage.Mock |> Mox.expect(:get, fn _, _ -> <<0, 0, 0>> end)
+      Worker.ResourceCache.Mock |> Mox.expect(:get, 2, fn _, _, _ -> :resource_not_found end)
+      Worker.RawResourceStorage.Mock |> Mox.expect(:get, fn _, _, _ -> <<0, 0, 0>> end)
 
       Worker.Provisioner.Mock
       |> Mox.expect(:provision, 2, fn
@@ -80,7 +81,7 @@ defmodule InvokeTest do
 
     test "should return {:error, err} when no resource is available and its creation fails",
          %{function: function} do
-      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _ -> :resource_not_found end)
+      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _, _ -> :resource_not_found end)
 
       Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:error, "creation error"} end)
 
@@ -91,9 +92,9 @@ defmodule InvokeTest do
          %{
            function: function
          } do
-      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _ -> :resource_not_found end)
+      Worker.ResourceCache.Mock |> Mox.expect(:get, fn _, _, _ -> :resource_not_found end)
       Worker.Provisioner.Mock |> Mox.expect(:provision, fn _ -> {:error, :code_not_found} end)
-      Worker.RawResourceStorage.Mock |> Mox.expect(:get, fn _, _ -> :resource_not_found end)
+      Worker.RawResourceStorage.Mock |> Mox.expect(:get, fn _, _, _ -> :resource_not_found end)
       assert {:error, :code_not_found, handler_pid} = InvokeFunction.invoke(function)
       assert is_pid(handler_pid)
     end


### PR DESCRIPTION
This PR adds the correct handling of the `delete` message for functions. Specifically, now the core sends a `delete` message to all workers when a function is removed, ensuring that the old code is not running on the platform after deletion.

Additionally:

- adds a new `hash` field to functions. This is calculated from the function's code, and identifies each `invoke`/`update`/`delete` command to ensure the correct version of the function is being targeted on workers;
- pushes the new code to workers when issuing an `update` command;
- extends the `cleanup` method on workers to target `RawResourceStorage` as well
- fixes a bug in the release of both `core` and `worker`, where `node_ip` was being ignored

This closes #70.