### PR TITLE
Add configurable Prometheus host

### DIFF
--- a/core/config/runtime.exs
+++ b/core/config/runtime.exs
@@ -17,6 +17,7 @@ import Config
 config :iex, default_prompt: ">>>"
 
 config :core, store_on_create: System.get_env("STORE_ON_CREATE") || "true"
+config :core, prometheus_host: System.get_env("PROMETHEUS_HOST") || "prometheus"
 
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the

--- a/core/lib/core/adapters/telemetry/collector.ex
+++ b/core/lib/core/adapters/telemetry/collector.ex
@@ -21,7 +21,7 @@ defmodule Core.Adapters.Telemetry.Collector do
   require Logger
   alias Core.Adapters.Telemetry.MetricsServer
 
-  @prom_url_query "http://prometheus:9090/api/v1/query?"
+  @prom_url_query "/api/v1/query?"
   # @beam_memory_allocated "worker_prom_ex_beam_memory_allocated_bytes"
   @os_mon_prefix "worker_prom_ex_os_mon_resources_"
   @available_mem "available_mem"
@@ -141,8 +141,9 @@ defmodule Core.Adapters.Telemetry.Collector do
 
   @spec pull_metrics(atom()) :: {:ok, map()} | {:error, any()}
   defp pull_metrics(worker) do
+    prom_host = Application.fetch_env!(:core, :prometheus_host)
     prom_query = :uri_string.compose_query([{"query", "{node=\"#{Atom.to_string(worker)}\"}"}])
-    prom_uri = "#{@prom_url_query}#{prom_query}"
+    prom_uri = "http://#{prom_host}:9090#{@prom_url_query}#{prom_query}"
 
     response = :httpc.request(:get, {prom_uri, []}, [], [])
 


### PR DESCRIPTION
This PR simply adds `PROMETHEUS_HOST` as an environment variable for the `core` component. This removes the hardcoded requirement for a host called `prometheus` in the `Core.Adapters.Telemetry.Collector` module. 