### PR TITLE
miniSL integration

### DIFF
--- a/data/lib/function_metadata.ex
+++ b/data/lib/function_metadata.ex
@@ -19,10 +19,26 @@ defmodule Data.FunctionMetadata do
   ## Fields
     - tag: a string containing the function's tag. Can be anything, generally used with custom scheduling policies or metrics.
     - capacity: the amount of memory this function requires to be allocated on a worker
+    - params: a list of strings, representing the names of the parameters of the function, ordered
+    - main_func: the main function to be called in the function
+    - miniSL_services:
+                a list of tuples, containing the methods, URLs and request/response fields of
+                declared services.
+                The input fields will be encoded in a JSON payload (field : value), in order.
+                The output fields work the same as the :params field in this struct.
+                Each input/output field is itself a tuple {field_name, field_type}.
+                Currently used for the miniSL language.
+                The list must contain the services in order of declaration in the function.
   """
+  @type param :: {String.t(), :int | :float | :bool | :string | :array}
+  @type svc :: {:get | :post | :put | :delete, String.t(), [param()], [param()]}
+
   @type t :: %__MODULE__{
           tag: String.t(),
-          capacity: integer()
+          capacity: integer(),
+          params: [String.t()],
+          main_func: String.t(),
+          miniSL_services: [svc()]
         }
-  defstruct tag: nil, capacity: -1
+  defstruct tag: nil, capacity: -1, params: [], main_func: nil, miniSL_services: []
 end

--- a/worker/lib/worker/adapters/runtime/wasm/imports.ex
+++ b/worker/lib/worker/adapters/runtime/wasm/imports.ex
@@ -19,6 +19,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Imports do
   The imports are functions that are called by the WASM code. They get the WASM context as first
   argument, which contains the memory and the caller.
   """
+  alias Data.FunctionMetadata
   require Logger
 
   def fl_imports(input_payload, agent) do
@@ -93,86 +94,227 @@ defmodule Worker.Adapters.Runtime.Wasm.Imports do
              header: {header_ptr, header_len},
              body: {body_ptr, body_len}
            }
-         }
+         } = params
        ) do
     caller = context.caller
     memory = context.memory
 
-    poison_method =
-      case method do
-        0 -> :get
-        1 -> :post
-        2 -> :put
-        3 -> :delete
+    if method == -1 or uri_len == -1 do
+      http_svc_request(context, params)
+    else
+      poison_method =
+        case method do
+          0 -> :get
+          1 -> :post
+          2 -> :put
+          3 -> :delete
+        end
+
+      uri = Wasmex.Memory.read_string(caller, memory, uri_ptr, uri_len)
+      headers = Wasmex.Memory.read_string(caller, memory, header_ptr, header_len)
+
+      # headers are encoded client-side as a single string, with "\n" separators between couples
+      # and ":" separators between key and value, e.g.
+      # Content-Type:application/json\nAge:12345
+      poison_headers =
+        headers
+        |> String.split("\n")
+        |> Enum.map(fn s -> s |> String.split(":") |> List.to_tuple() end)
+
+      body = Wasmex.Memory.read_string(caller, memory, body_ptr, body_len)
+
+      Logger.debug("WASM sending HTTP request: #{poison_method} #{uri}")
+
+      request = %HTTPoison.Request{
+        method: poison_method,
+        url: uri,
+        body: body,
+        headers: poison_headers
+      }
+
+      case HTTPoison.request(request) do
+        {:ok, %{status_code: status_code, body: response_body}} ->
+          # write status to memory
+          Wasmex.Memory.write_binary(
+            caller,
+            memory,
+            status_ptr,
+            <<status_code::integer-unsigned-size(16)-little>>
+          )
+
+          # write body length to memory
+          Wasmex.Memory.write_binary(
+            caller,
+            memory,
+            response_len_ptr,
+            <<String.length(response_body)::integer-unsigned-size(32)-little>>
+          )
+
+          # write body to memory
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, response_body)
+
+          nil
+
+        {:error, err} ->
+          # in case of an unexpected error, the status is 0 and the body is empty
+
+          Wasmex.Memory.write_binary(
+            caller,
+            memory,
+            status_ptr,
+            <<0::integer-unsigned-size(16)-little>>
+          )
+
+          Wasmex.Memory.write_binary(
+            caller,
+            memory,
+            response_len_ptr,
+            <<String.length("")::integer-unsigned-size(32)-little>>
+          )
+
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, "")
+
+          Logger.error("Error in HTTP request from WASM function #{err}")
+          nil
       end
+    end
+  end
 
-    uri = Wasmex.Memory.read_string(caller, memory, uri_ptr, uri_len)
-    headers = Wasmex.Memory.read_string(caller, memory, header_ptr, header_len)
+  defp http_svc_request(
+         %{
+           caller: caller,
+           memory: memory,
+           metadata: %FunctionMetadata{} = metadata,
+           last_ptr: last_ptr
+         },
+         %{
+           output: %{response: {response_ptr, _}},
+           input: %{
+             uri: {svc_idx, _},
+             body: {body_ptr, _}
+           }
+         }
+       ) do
+    {poison_method, uri, req_params, resp_params} = metadata.miniSL_services |> Enum.at(svc_idx)
 
-    # headers are encoded client-side as a single string, with "\n" separators between couples
-    # and ":" separators between key and value, e.g.
-    # Content-Type:application/json\nAge:12345
-    poison_headers =
-      headers
-      |> String.split("\n")
-      |> Enum.map(fn s -> s |> String.split(":") |> List.to_tuple() end)
+    poison_headers = [{"Content-Type", "application/json"}]
 
-    body = Wasmex.Memory.read_string(caller, memory, body_ptr, body_len)
-
-    Logger.debug("WASM sending HTTP request: #{poison_method} #{uri}")
+    # body = Wasmex.Memory.read_string(caller, memory, body_ptr, body_len)
+    body = parse_svc_body(caller, memory, body_ptr, req_params, []) |> Enum.into(%{})
+    Logger.debug("WASM sending HTTP request from service #{svc_idx}: #{poison_method} #{uri}")
 
     request = %HTTPoison.Request{
       method: poison_method,
       url: uri,
-      body: body,
+      body: Jason.encode!(body),
       headers: poison_headers
     }
 
     case HTTPoison.request(request) do
-      {:ok, %{status_code: status_code, body: response_body}} ->
-        # write status to memory
-        Wasmex.Memory.write_binary(
-          caller,
-          memory,
-          status_ptr,
-          <<status_code::integer-unsigned-size(16)-little>>
-        )
-
-        # write body length to memory
-        Wasmex.Memory.write_binary(
-          caller,
-          memory,
-          response_len_ptr,
-          <<String.length(response_body)::integer-unsigned-size(32)-little>>
-        )
-
+      {:ok, %{status_code: _status_code, body: response_body}} ->
         # write body to memory
+        write_svc_response(caller, memory, last_ptr, response_ptr, response_body, resp_params)
         Wasmex.Memory.write_binary(caller, memory, response_ptr, response_body)
-
         nil
 
       {:error, err} ->
-        # in case of an unexpected error, the status is 0 and the body is empty
+        Wasmex.Memory.write_binary(caller, memory, response_ptr, <<0>>)
 
-        Wasmex.Memory.write_binary(
-          caller,
-          memory,
-          status_ptr,
-          <<0::integer-unsigned-size(16)-little>>
-        )
-
-        Wasmex.Memory.write_binary(
-          caller,
-          memory,
-          response_len_ptr,
-          <<String.length("")::integer-unsigned-size(32)-little>>
-        )
-
-        Wasmex.Memory.write_binary(caller, memory, response_ptr, "")
-
-        Logger.error("Error in HTTP request from WASM function #{err}")
+        Logger.error("Error in HTTP request from WASM function #{inspect(err)}")
         nil
     end
+  end
+
+  defp parse_svc_body(_, _, _, [], result) do
+    result
+  end
+
+  defp parse_svc_body(caller, memory, body_ptr, [{param_name, param_type} | rest], result) do
+    {value, offset} =
+      case param_type do
+        :bool ->
+          <<x::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr, 4)
+          {x, 4}
+
+        :int ->
+          <<x::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr, 4)
+          {x, 4}
+
+        :float ->
+          <<x::float-size(64)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr, 8)
+          {x, 8}
+
+        :string ->
+          <<ptr::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr, 4)
+          <<len::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr + 4, 4)
+          str = Wasmex.Memory.read_string(caller, memory, ptr, len)
+          {str, 8}
+
+        :array ->
+          <<ptr::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr, 4)
+          <<len::size(32)-little>> = Wasmex.Memory.read_binary(caller, memory, body_ptr + 4, 4)
+          bin_arr = Wasmex.Memory.read_string(caller, memory, ptr, len)
+          arr = for <<x::size(32)-little <- bin_arr>>, do: x
+          {arr, 8}
+      end
+
+    parse_svc_body(caller, memory, body_ptr + offset, rest, [{param_name, value} | result])
+  end
+
+  defp write_svc_response(_, _, _, _, _, []) do
+    nil
+  end
+
+  defp write_svc_response(caller, memory, last_ptr, response_ptr, response_body, [
+         {param_name, param_type} | rest
+       ]) do
+    val = Jason.decode!(response_body)[param_name]
+
+    {offset, fl_offset} =
+      case param_type do
+        :bool ->
+          bin_val =
+            if val do
+              1
+            else
+              0
+            end
+
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, <<bin_val::size(32)-little>>)
+          {4, 0}
+
+        :int ->
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, <<val::size(32)-little>>)
+          {4, 0}
+
+        :float ->
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, <<val::float-size(64)-little>>)
+          {8, 0}
+
+        :string ->
+          len = byte_size(val)
+          Wasmex.Memory.write_binary(caller, memory, last_ptr, val)
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, <<last_ptr::size(32)-little>>)
+          Wasmex.Memory.write_binary(caller, memory, response_ptr + 4, <<len::size(32)-little>>)
+          {8, len}
+
+        :array ->
+          arr = val |> Enum.into(<<>>, fn x -> <<x::size(32)-little>> end)
+          len = byte_size(arr)
+          Wasmex.Memory.write_binary(caller, memory, last_ptr, arr)
+          Wasmex.Memory.write_binary(caller, memory, response_ptr, <<last_ptr::size(32)-little>>)
+          Wasmex.Memory.write_binary(caller, memory, response_ptr + 4, <<len::size(32)-little>>)
+          {8, len}
+      end
+
+    write_svc_response(
+      caller,
+      memory,
+      last_ptr + fl_offset,
+      response_ptr + offset,
+      response_body,
+      rest
+    )
   end
 
   # Load the guest response indicated by the location and length into the :response state field.

--- a/worker/lib/worker/adapters/runtime/wasm/runner.ex
+++ b/worker/lib/worker/adapters/runtime/wasm/runner.ex
@@ -59,7 +59,8 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
         %ExecutionResource{
           resource: wasm_module
         }
-      ) do
+      )
+      when metadata != nil do
     Logger.debug("Runner: Invoking #{mod}/#{name} with args #{inspect(args)}")
 
     # Spin up an agent to store the result of the invocation
@@ -74,6 +75,17 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
     # Stop the agent
     Agent.stop(result_agent)
     res
+  end
+
+  @impl true
+  def run_function(
+        %FunctionStruct{name: _name, module: _mod} = function,
+        args,
+        %ExecutionResource{
+          resource: _wasm_module
+        } = resource
+      ) do
+    run_function(function |> Map.put(:metadata, %FunctionMetadata{}), args, resource)
   end
 
   defp perform_invocation(wasm_module, input_args, agent, %FunctionMetadata{} = metadata) do

--- a/worker/lib/worker/adapters/runtime/wasm/runner.ex
+++ b/worker/lib/worker/adapters/runtime/wasm/runner.ex
@@ -42,9 +42,9 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
   @wasm_invoke "__invoke"
   @exec_timeout 60_000
 
+  alias Data.ExecutionResource
   alias Data.FunctionMetadata
   alias Data.FunctionStruct
-  alias Data.ExecutionResource
   alias Worker.Adapters.Runtime.Wasm.Engine
   alias Worker.Adapters.Runtime.Wasm.Imports
 

--- a/worker/lib/worker/adapters/runtime/wasm/runner.ex
+++ b/worker/lib/worker/adapters/runtime/wasm/runner.ex
@@ -42,6 +42,8 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
   @wasm_invoke "__invoke"
   @exec_timeout 60_000
 
+  alias Data.FunctionMetadata
+  alias Data.FunctionStruct
   alias Data.ExecutionResource
   alias Worker.Adapters.Runtime.Wasm.Engine
   alias Worker.Adapters.Runtime.Wasm.Imports
@@ -52,7 +54,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
 
   @impl true
   def run_function(
-        %{name: name, module: mod},
+        %FunctionStruct{name: name, module: mod, metadata: metadata},
         args,
         %ExecutionResource{
           resource: wasm_module
@@ -64,7 +66,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
     {:ok, result_agent} = Agent.start_link(fn -> %{error: nil, response: nil} end)
 
     res =
-      perform_invocation(wasm_module, args, result_agent)
+      perform_invocation(wasm_module, args, result_agent, metadata)
       |> parse_return(result_agent)
 
     Logger.debug("Runner: returning result #{inspect(res)}")
@@ -74,7 +76,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
     res
   end
 
-  defp perform_invocation(wasm_module, input_args, agent) do
+  defp perform_invocation(wasm_module, input_args, agent, %FunctionMetadata{} = metadata) do
     parsed_input = Jason.encode!(input_args)
 
     Logger.debug(
@@ -93,30 +95,139 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
       # if it succeeeds, set guest_response, return 0
       Logger.debug("Runner: Invoking exported #{@wasm_invoke}")
 
-      Wasmex.Instance.call_exported_function(
-        store,
-        instance,
-        @wasm_invoke,
-        [
-          byte_size(parsed_input)
-        ],
-        {self(), :from}
-      )
-
-      handle_wasm_messages(imports)
+      if Wasmex.Instance.function_export_exists(store, instance, @wasm_invoke) do
+        call_wasm_invoke(store, instance, parsed_input, metadata, imports)
+      else
+        call_main_func(store, instance, input_args, metadata, imports)
+      end
     end
   end
 
-  defp handle_wasm_messages(imports) do
+  defp call_wasm_invoke(store, instance, parsed_input, metadata, imports) do
+    Wasmex.Instance.call_exported_function(
+      store,
+      instance,
+      @wasm_invoke,
+      [
+        byte_size(parsed_input)
+      ],
+      {self(), :from}
+    )
+
+    handle_wasm_messages(imports, metadata, 0)
+  end
+
+  defp call_main_func(
+         store,
+         instance,
+         input_args,
+         %FunctionMetadata{main_func: main_func, params: []} = metadata,
+         imports
+       )
+       when is_list(input_args) do
+    {translated_args, last_ptr} =
+      input_args
+      |> Enum.reduce({[], 0}, fn value, {translated_vals, last_ptr} ->
+        {translated_val, new_ptr} = translate_argument(value, store, instance, last_ptr)
+        {translated_val ++ translated_vals, new_ptr}
+      end)
+
+    translated_args = translated_args |> Enum.reverse()
+
+    Wasmex.Instance.call_exported_function(
+      store,
+      instance,
+      main_func,
+      [last_ptr + 65_536 | translated_args],
+      {self(), :from}
+    )
+
+    handle_wasm_messages(imports, metadata, last_ptr)
+  end
+
+  defp call_main_func(
+         store,
+         instance,
+         input_args,
+         %FunctionMetadata{main_func: main_func, params: [_ | _] = params_names} = metadata,
+         imports
+       )
+       when is_map(input_args) do
+    {translated_args, last_ptr} =
+      params_names
+      |> Enum.reduce({[], 0}, fn name, {translated_vals, last_ptr} ->
+        value = input_args |> Map.get(name)
+        {translated_val, new_ptr} = translate_argument(value, store, instance, last_ptr)
+        {translated_val ++ translated_vals, new_ptr}
+      end)
+
+    translated_args = translated_args |> Enum.reverse()
+
+    Wasmex.Instance.call_exported_function(
+      store,
+      instance,
+      main_func,
+      [last_ptr + 65_536 | translated_args],
+      {self(), :from}
+    )
+
+    handle_wasm_messages(imports, metadata, last_ptr)
+  end
+
+  defp translate_argument(value, store, instance, last_ptr) when is_binary(value) do
+    {:ok, memory} = Wasmex.Instance.memory(store, instance)
+    len = byte_size(value)
+    Wasmex.Memory.write_binary(store, memory, last_ptr, value)
+    {[len, last_ptr], last_ptr + len}
+  end
+
+  defp translate_argument(value, store, instance, last_ptr) when is_list(value) do
+    {:ok, memory} = Wasmex.Instance.memory(store, instance)
+    bin_value = value |> Enum.into(<<>>, fn x -> <<x::32>> end)
+    len = byte_size(bin_value)
+    Wasmex.Memory.write_binary(store, memory, last_ptr, bin_value)
+    {[len, last_ptr], last_ptr + len}
+  end
+
+  defp translate_argument(value, _store, _instance, last_ptr) when is_boolean(value) do
+    if value == true do
+      {[1], last_ptr}
+    else
+      {[0], last_ptr}
+    end
+  end
+
+  defp translate_argument(value, _store, _instance, last_ptr)
+       when is_integer(value) or is_float(value) do
+    {[value], last_ptr}
+  end
+
+  # NOTE: last_ptr is a temporary solution to handle the miniSL case of string responses.
+  # miniSL gives us the pointer to the response (which will hold str_ptr and str_len), but no
+  # information as to where the string itself is allocated. We use last_ptr to have an idea
+  # of where we can allocate (between last_ptr and the first miniSL allocation we have 64K of free memory).
+  # This will be very likely changed in the future, or limited to the specific miniSL case to avoid confusion
+  # in the code.
+  defp handle_wasm_messages(imports, %FunctionMetadata{} = metadata, last_ptr) do
     receive do
       {:returned_function_call, {:ok, result}, _} ->
-        Logger.debug("Wasm: Function returned successfully: #{inspect(result)}}")
+        Logger.debug("Wasm: Function returned successfully: #{inspect(result)}")
         {:ok, result}
 
       {:invoke_callback, namespace_name, import_name, context, params, token} ->
         Logger.debug("Runner: requested invocation of import #{namespace_name}: #{import_name}")
-        invoke_import_fn(namespace_name, import_name, context, params, token, imports)
-        handle_wasm_messages(imports)
+
+        invoke_import_fn(
+          namespace_name,
+          import_name,
+          context |> Map.put(:last_ptr, last_ptr),
+          params,
+          metadata,
+          token,
+          imports
+        )
+
+        handle_wasm_messages(imports, metadata, last_ptr)
 
       value ->
         Logger.error("Runner: WebAssembly runtime failed to run function: #{inspect(value)}")
@@ -131,6 +242,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
          import_name,
          context,
          params,
+         %FunctionMetadata{} = metadata,
          token,
          imports
        ) do
@@ -139,7 +251,8 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
         context,
         %{
           memory: Wasmex.Memory.__wrap_resource__(Map.get(context, :memory)),
-          caller: Wasmex.StoreOrCaller.__wrap_resource__(Map.get(context, :caller))
+          caller: Wasmex.StoreOrCaller.__wrap_resource__(Map.get(context, :caller)),
+          metadata: metadata
         }
       )
 
@@ -150,6 +263,7 @@ defmodule Worker.Adapters.Runtime.Wasm.Runner do
           |> Map.get(namespace_name, %{})
           |> Map.get(import_name)
 
+        # either use special case for HTTP request, or change context to include function metadata
         {true, apply(callback, [context | params])}
       rescue
         e in RuntimeError -> {false, e.message}

--- a/worker/lib/worker/domain/invoke_function.ex
+++ b/worker/lib/worker/domain/invoke_function.ex
@@ -49,7 +49,7 @@ defmodule Worker.Domain.InvokeFunction do
 
     case ProvisionResource.provision(f) do
       {:ok, resource} ->
-        Runner.run_function(function, args, resource)
+        Runner.run_function(f, args, resource)
 
       {:error, :code_not_found} ->
         invoke_no_code(f, args)

--- a/worker/test/integration/adapters/wasm_test.exs
+++ b/worker/test/integration/adapters/wasm_test.exs
@@ -103,7 +103,7 @@ defmodule Integration.Adapters.WasmTest do
     end
 
     test "invalid input" do
-      function = %{name: "f", module: "m"}
+      function = %Data.FunctionStruct{name: "f", module: "m", hash: <<0>>}
       args = %{}
 
       resource = %Data.ExecutionResource{
@@ -184,32 +184,32 @@ defmodule Integration.Adapters.WasmTest do
       assert %{
                "status" => "200",
                "payload" => %{
-                 "brand" => "Apple",
-                 "category" => "smartphones",
+                 "brand" => _,
+                 "category" => _,
                  "id" => 1,
-                 "price" => 549,
-                 "rating" => 4.69,
-                 "stock" => 94,
-                 "title" => "iPhone 9"
+                 "price" => _,
+                 "rating" => _,
+                 "stock" => _,
+                 "title" => _
                }
              } = get_result
 
-      assert post_result == %{
+      assert %{
                "status" => "200",
                "payload" => %{
                  "title" => "product-fl",
-                 "id" => 101
+                 "id" => _
                }
-             }
+             } = post_result
 
       assert %{
                "payload" => %{
-                 "brand" => "Apple",
-                 "category" => "smartphones",
-                 "id" => 1,
-                 "price" => 549,
-                 "rating" => 4.69,
-                 "stock" => 94,
+                 "brand" => _,
+                 "category" => _,
+                 "id" => _,
+                 "price" => _,
+                 "rating" => _,
+                 "stock" => _,
                  "title" => "product-fl"
                },
                "status" => "200"
@@ -217,16 +217,16 @@ defmodule Integration.Adapters.WasmTest do
 
       assert %{
                "payload" => %{
-                 "brand" => "Apple",
-                 "category" => "smartphones",
+                 "brand" => _,
+                 "category" => _,
                  "deletedOn" => _,
-                 "discountPercentage" => 12.96,
+                 "discountPercentage" => _,
                  "id" => 1,
                  "isDeleted" => true,
-                 "price" => 549,
-                 "rating" => 4.69,
-                 "stock" => 94,
-                 "title" => "iPhone 9"
+                 "price" => _,
+                 "rating" => _,
+                 "stock" => _,
+                 "title" => _
                },
                "status" => "200"
              } = delete_result


### PR DESCRIPTION
This PR allows FunLess to run Wasm binaries compiled from miniSL code. Moreover, it also fixes some tests for the Wasm `runner`, setting the correct data types and handling the changes in the DummyJSON dataset.

None of these changes should be destructive, therefore the original functionality is preserved. 
The changes only affect the Worker and the `FunctionMetadata` struct.