### PR TITLE
cAPP integration

### DIFF
--- a/core/lib/core/domain/policies/capp.ex
+++ b/core/lib/core/domain/policies/capp.ex
@@ -132,7 +132,8 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.CAPP do
           | rest
         ],
         workers,
-        %Data.FunctionStruct{metadata: %{miniSL_services: svc}} = function
+        %Data.FunctionStruct{metadata: %{miniSL_services: svc, miniSL_equation: equation}} =
+          function
       ) do
     filtered_workers =
       block_workers
@@ -181,10 +182,6 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.CAPP do
                 %Data.Worker{resources: nil} = w ->
                   {w, urls |> Enum.map(fn _ -> @unknown_latency end)}
               end)
-
-            # TODO: extract equation from function metadata
-            # PLACEHOLDER
-            equation = {}
 
             total_latencies =
               worker_latencies

--- a/core/lib/core/domain/policies/capp.ex
+++ b/core/lib/core/domain/policies/capp.ex
@@ -1,0 +1,226 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.CAPP do
+  @moduledoc """
+  Implementation of the SchedulingPolicy protocol for the CAPP datatype.
+  """
+  alias Data.Configurations.CAPP
+  alias Data.Configurations.CAPP.Block
+  alias Data.Configurations.CAPP.Tag
+
+  @unknown_latency 999_999
+
+  @type select_errors ::
+          {:error, :no_workers}
+          | {:error, :no_valid_workers}
+          | {:error, :invalid_input}
+          | {:error, :no_matching_tag}
+          | {:error, :no_function_metadata}
+
+  @doc """
+  Selects a suitable worker to host the given function, according to the provided APP configuration.
+
+  ## Parameters
+  - configuration: an APP script (Data.Configurations.APP), generally obtained through parsing using the Core.Domain.Policies.Parsers.APP module.
+  - workers: a list of Data.Worker structs, each with relevant worker metrics.
+  - function: a Data.FunctionStruct struct, with the necessary function information. It must contain function metadata, specifically a tag and a capacity.
+
+  ## Returns
+  - {:ok, wrk} if a suitable worker was found, with `wrk` being the worker.
+  - {:error, :no_workers} if an empty list of workers is received.
+  - {:error, :no_valid_workers} if no suitable worker was found (but a non-empty list of workers was given in input).
+  - {:error, :no_matching_tag} if the function's tag does not exist in the given configuration, and no default tag was specified in it.
+  - {:error, :no_function_metadata} if the given FunctionStruct does not include the necessary metadata (i.e. tag, capacity).
+  - {:error, :invalid_input} if the given input was invalid in any other way (e.g. wrong types).
+  """
+  @spec select(CAPP.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
+          {:ok, Data.Worker.t()} | select_errors()
+  def select(
+        %CAPP{tags: tags} = _configuration,
+        [_ | _] = workers,
+        %Data.FunctionStruct{metadata: %{tag: tag_name, capacity: _function_capacity}} = function
+      ) do
+    default = tags |> Map.get("default")
+    tag = tags |> Map.get(tag_name, default)
+
+    case tag do
+      %Tag{blocks: [_ | _] = blocks, followup: followup} ->
+        mapped_workers = workers |> Map.new(fn %Data.Worker{long_name: n} = w -> {n, w} end)
+
+        case schedule_on_blocks(blocks, mapped_workers, function) do
+          {:error, :no_valid_workers}
+          when followup == :fail or (followup == :default and is_nil(default)) ->
+            {:error, :no_valid_workers}
+
+          {:error, :no_valid_workers} when followup == :default ->
+            %Tag{blocks: [_ | _] = default_blocks} = default
+            schedule_on_blocks(default_blocks, mapped_workers, function)
+
+          {:ok, %Data.Worker{} = wrk} ->
+            {:ok, wrk}
+        end
+
+      nil ->
+        {:error, :no_matching_tag}
+    end
+  end
+
+  def select(%CAPP{tags: _}, [], _) do
+    {:error, :no_workers}
+  end
+
+  def select(%CAPP{tags: _}, _, %Data.FunctionStruct{metadata: nil}) do
+    {:error, :no_function_metadata}
+  end
+
+  def select(_, _, _) do
+    {:error, :invalid_input}
+  end
+
+  @doc """
+  Helper function, recursively explores the blocks specified for a function's tag in an APP configuration.
+
+  ## Parameters
+  - blocks: a list of APP blocks (Data.Configurations.APP.Block), extracted from the function's tag definition in the APP configuration.
+  - workers: a map with String keys and Data.Worker values; the keys are each worker's "long_name" attribute, which are the same names used inside the APP configuration.
+  - function: a Data.FunctionStruct struct, with the necessary function information. It must contain function metadata, specifically a tag and a capacity.
+
+  ## Returns
+  - {:ok, wrk} if a suitable worker was found, with `wrk` being the worker.
+  - {:error, :no_valid_workers} if no suitable worker was found (but a non-empty list of workers was given in input).
+  """
+  @spec schedule_on_blocks([Block.t()], %{String.t() => Data.Worker.t()}, Data.FunctionStruct.t()) ::
+          {:ok, Data.Worker.t()} | {:error, :no_valid_workers}
+  def schedule_on_blocks(
+        [
+          %Block{
+            workers: "*"
+          } = block
+          | rest
+        ],
+        workers,
+        function
+      ) do
+    new_block = block |> Map.put(:workers, workers |> Map.keys())
+    schedule_on_blocks([new_block | rest], workers, function)
+  end
+
+  def schedule_on_blocks(
+        [
+          %Block{
+            workers: block_workers,
+            strategy: strategy,
+            invalidate: %{
+              capacity_used: invalidate_capacity,
+              max_concurrent_invocations: invalidate_invocations,
+              max_latency: invalidate_latency
+            }
+          }
+          | rest
+        ],
+        workers,
+        %Data.FunctionStruct{metadata: %{miniSL_services: svc}} = function
+      ) do
+    filtered_workers =
+      block_workers
+      |> Enum.flat_map(fn w ->
+        case Map.get(workers, w) do
+          nil -> []
+          wrk -> [wrk]
+        end
+      end)
+      |> Enum.filter(fn w ->
+        is_valid?(w, function, invalidate_capacity, invalidate_invocations, invalidate_latency)
+      end)
+
+    case filtered_workers do
+      [] ->
+        schedule_on_blocks(rest, workers, function)
+
+      [h | _] = wrk ->
+        case strategy do
+          :"best-first" ->
+            {:ok, h}
+
+          :random ->
+            {:ok, Enum.random(wrk)}
+
+          :platform ->
+            Core.Domain.Policies.SchedulingPolicy.select(
+              %Data.Configurations.Empty{},
+              wrk,
+              function
+            )
+
+          :min_strategy ->
+            # TODO: use calculated total latency
+            urls = svc |> Enum.map(fn {_method, url, _request, _response} -> url end)
+            {:ok, Enum.random(wrk)}
+        end
+    end
+  end
+
+  def schedule_on_blocks([], _, _) do
+    {:error, :no_valid_workers}
+  end
+
+  @doc """
+  Helper function, checks if a worker is valid according to the given "invalidate" options and a certain function.
+  The basic validity check consists in ensuring that the worker has enough available memory to host the function, given its capacity.
+
+  ## Parameters
+  - w: a Data.Worker struct, with defined memory metrics and amount of concurrent functions.
+  - function: a Data.FunctionStruct struct, with the necessary function information. It must contain function metadata, specifically its capacity.
+  - invalidate_capacity: either a number or the :infinity atom, it's the maximum memory (percentage relative to the total worker memory) that can
+                        be occupied in the worker, before it is considered invalid.
+  - invalidate_invocations: either a number or the :infinity atom, it's the maximum number of concurrent functions the worker can host before being considered invalid.
+
+  ## Returns
+  - true if the worker can host the function, given the conditions
+  - false otherwise
+  """
+  @spec is_valid?(
+          Data.Worker.t(),
+          Data.FunctionStruct.t(),
+          number() | :infinity,
+          number() | :infinity,
+          number() | :infinity
+        ) :: boolean
+  def is_valid?(
+        %Data.Worker{
+          concurrent_functions: c,
+          resources: %Data.Worker.Metrics{
+            memory: %{available: available, total: total}
+          }
+        } = _w,
+        %Data.FunctionStruct{
+          metadata: %Data.FunctionMetadata{
+            capacity: function_capacity,
+            miniSL_services: svc
+          }
+        },
+        invalidate_capacity,
+        invalidate_invocations,
+        invalidate_latency
+      ) do
+    # TODO: consider calculated max_latency
+    urls = svc |> Enum.map(fn {_method, url, _request, _response} -> url end)
+
+    function_capacity <= available and
+      (invalidate_invocations == :infinity or c < invalidate_invocations) and
+      (invalidate_capacity == :infinity or
+         (total - available + function_capacity) / total * 100 <= invalidate_capacity)
+  end
+end

--- a/core/lib/core/domain/policies/parsers/capp.ex
+++ b/core/lib/core/domain/policies/parsers/capp.ex
@@ -1,0 +1,225 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Policies.Parsers.CAPP do
+  @moduledoc """
+  Parser for cAPP configuration scripts.
+  Contains the main parse/1 function and several helper functions.
+
+  When the module is loaded, Data.Configurations.cAPP, Data.Configurations.CAPP.Block and Data.Configurations.CAPP.Tag
+  are loaded as well. This prevents errors when using String.to_existing_atom/1 in this module.
+  """
+  @on_load :load_atoms
+
+  defp load_atoms do
+    [Data.Configurations.CAPP, Data.Configurations.CAPP.Block, Data.Configurations.CAPP.Tag]
+    |> Enum.each(&Code.ensure_loaded?/1)
+
+    :ok
+  end
+
+  @doc """
+  Parses a given YAML string and builds the relevant cAPP configuration from it.
+
+  ## Parameters
+  - content: a String, containing the cAPP configuration as it was written in YAML.
+            Must be valid YAML.
+
+  ## Returns
+  - {:ok, app} if the string was parsed successfully, and the cAPP configuration was built.
+  - {:error, YamlElixir._} if the given content was not valid YAML.
+  - {:error, errors} if any error was encountered during the parsing.
+              The returned errors are a map, with tag names as keys, and the actual errors as values.
+              For each tag, each error can either be a single tuple (if the error was at the tag level),
+              or a list of tuples (one for each block where an error was found).
+              E.g. %{"t1" => [{:error, _}, {:error, _}], "t2" => {:error, :no_blocks}}
+
+  """
+  @spec parse(String.t()) ::
+          {:ok, Data.Configurations.CAPP.t()} | {:error, %{String.t() => {:error, any}}}
+  def parse(content) do
+    with {:ok, yaml} <- YamlElixir.read_from_string(content) do
+      yaml |> parse_script()
+    end
+  end
+
+  @doc """
+  Helper function, performs the actual parsing of the YAML file into an cAPP struct.
+
+  ## Parameters
+  - yaml: parsed YAML. Should be a list, with each element encoding a single tag.
+
+  ## Returns
+  - {:error, :unknown_construct} if the given parsed YAML has an incorrect structure.
+  - See returns values for parse/1.
+  """
+  @spec parse_script([map()]) ::
+          {:ok, Data.Configurations.CAPP.t()} | {:error, %{String.t() => {:error, any}}}
+  def parse_script([_ | _] = yaml) do
+    {parsed, errors} =
+      yaml
+      |> Enum.map(fn tag -> tag |> Map.to_list() |> parse_tag end)
+      |> Enum.split_with(&match?({_, {:ok, _}}, &1))
+
+    case errors do
+      [] ->
+        {:ok,
+         %Data.Configurations.CAPP{
+           tags:
+             parsed
+             |> Enum.map(fn {tag_name, {:ok, tag}} -> {tag_name, tag} end)
+             |> Enum.into(%{})
+         }}
+
+      [_ | _] ->
+        {:error, errors |> Enum.into(%{})}
+    end
+  end
+
+  def parse_script(_) do
+    {:error, :unknown_construct}
+  end
+
+  @doc """
+  Helper function, parses a single tag and builds the relative CAPP.Tag struct.
+
+  ## Parameters
+  - [_, _]: should be a 2-element list, with shape:
+            [{tag_name, tag}, {"followup", followup}] or [{"followup", followup}, {tag_name, tag}].
+            The order of the two elements can vary, as the list is built from a Map, and the keys
+            are in lexicographic order; therefore, two different clauses are given for this function,
+            with the same behaviour.
+
+  ## Returns
+  - {tag_name, tag} if the tag was parsed successfully, with "tag" being an CAPP.Tag struct.
+  - {tag_name, {:error, :no_blocks}} when the given YAML has no blocks associated with the tag.
+  - {tag_name, {:error, :unknown_followup}} when the given YAML has a followup value that is neither "default" nor "fail".
+  - {tag_name, {:error, :unknown_construct}} when the given YAML is malformed or has additional keys in the tag definition.
+  - See returns values for parse/1.
+  """
+  @spec parse_tag([{String.t(), any}]) ::
+          {String.t(),
+           {:error, :no_blocks | :unknown_construct | :unknown_followup | [{:error, any}]}
+           | {:ok, Data.Configurations.CAPP.Tag.t()}}
+  def parse_tag([{"followup", _} = followup, {_, _} = tag]) do
+    parse_tag([tag, followup])
+  end
+
+  def parse_tag([{tag_name, [_ | _] = blocks}, {"followup", followup}])
+      when followup in ["default", "fail"] do
+    {parsed, errors} =
+      blocks |> Enum.map(&parse_block/1) |> Enum.split_with(&match?({:ok, _}, &1))
+
+    tag_content =
+      case errors do
+        [] ->
+          {:ok,
+           %Data.Configurations.CAPP.Tag{
+             blocks:
+               parsed
+               |> Enum.map(fn {:ok, block} -> block end),
+             followup: String.to_existing_atom(followup)
+           }}
+
+        [_ | _] ->
+          {:error, errors}
+      end
+
+    {tag_name, tag_content}
+  end
+
+  def parse_tag([{_tag_name, _blocks = [_ | _]} = tag]) do
+    parse_tag([tag, {"followup", "fail"}])
+  end
+
+  def parse_tag([{tag_name, _blocks = [_ | _]}, {"followup", _}]) do
+    {tag_name, {:error, :unknown_followup}}
+  end
+
+  def parse_tag([{tag_name, []} | _]) do
+    {tag_name, {:error, :no_blocks}}
+  end
+
+  def parse_tag([{tag_name, nil} | _]) do
+    {tag_name, {:error, :no_blocks}}
+  end
+
+  def parse_tag([{tag_name, _} | _]) do
+    {tag_name, {:error, :unknown_construct}}
+  end
+
+  @doc """
+  Helper function, parses a single block and builds the relative CAPP.Block struct.
+
+  ## Parameters
+  - block: a map, with a mandatory "workers" key.
+           Can also have a "strategy" key with either "random", "best-first", or "platform" value.
+           If the "strategy" key is missing, "best-first" is assumed as value.
+           Other missing fields are filled when building the struct.
+
+  ## Returns
+  - {:ok, block} if the block was parsed successfully, with "block" being an CAPP.Block struct.
+  - {:error, :no_block_workers} if the "workers" key was missing in the given block.
+  - See returns values for parse/1.
+  """
+  @spec parse_block(%{String.t() => any}) ::
+          {:ok, Data.Configurations.CAPP.Block.t()} | {:error, :no_block_workers}
+  def parse_block(%{"workers" => wrk, "strategy" => strategy} = block)
+      when strategy in ["random", "best-first", "platform", "min_latency"] and
+             (is_list(wrk) or is_binary(wrk)) do
+    block_with_atom_keys =
+      for {k, v} <- block, into: %{} do
+        {String.to_existing_atom(k), v}
+      end
+
+    capacity_used =
+      block
+      |> Map.get("invalidate", %{})
+      |> Map.get("capacity_used", :infinity)
+      |> then(fn x ->
+        if x != :infinity do
+          {n, _} = Integer.parse(x)
+          n
+        else
+          x
+        end
+      end)
+
+    max_concurrent_invocations =
+      block |> Map.get("invalidate", %{}) |> Map.get("max_concurrent_invocations", :infinity)
+
+    max_latency = block |> Map.get("invalidate", %{}) |> Map.get("max_latency", :infinity)
+
+    {:ok,
+     struct(
+       Data.Configurations.CAPP.Block,
+       block_with_atom_keys
+       |> Map.put(:invalidate, %{
+         capacity_used: capacity_used,
+         max_concurrent_invocations: max_concurrent_invocations,
+         max_latency: max_latency
+       })
+       |> Map.put(:strategy, strategy |> String.to_existing_atom())
+     )}
+  end
+
+  def parse_block(%{"workers" => wrk} = block)
+      when is_list(wrk) or is_binary(wrk) do
+    parse_block(block |> Map.put("strategy", "best-first"))
+  end
+
+  def parse_block(_) do
+    {:error, :no_block_workers}
+  end
+end

--- a/core/lib/core/domain/policies/support/capp_equations.ex
+++ b/core/lib/core/domain/policies/support/capp_equations.ex
@@ -1,0 +1,197 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Policies.Support.CappEquations do
+  @moduledoc """
+    Methods to tokenize, parse and evaluate equations produced by PUBS for programs
+    written in miniSL, to be used by cAPP policies.
+  """
+  @type token ::
+          :max
+          | :star
+          | :plus
+          | :lpar
+          | :rpar
+          | :lbrack
+          | :rbrack
+          | :comma
+          | :nat
+          | {:var, binary()}
+          | {:num, number()}
+  @type nat :: {:nat, binary()} | {:nat, {:sum, binary(), number()}}
+  @type max :: {:max, [exp()]}
+  @type sum :: {:sum, exp(), exp()}
+  @type prod :: {:prod, exp(), exp()}
+  @type num :: {:num, number()}
+  @type exp :: {} | nat | max | sum | prod | num
+
+  @spec tokenize(String.t()) :: [token()]
+  def tokenize(equation) do
+    equation = String.replace(equation, " ", "")
+    tokenize_chars(equation, [])
+  end
+
+  @spec tokenize_chars(String.t(), [token()]) :: [token()]
+  defp tokenize_chars(equation, tokens) when equation != "" do
+    {token, rest} =
+      case equation do
+        "+" <> rest ->
+          {:plus, rest}
+
+        "*" <> rest ->
+          {:star, rest}
+
+        "max" <> rest ->
+          {:max, rest}
+
+        "(" <> rest ->
+          {:lpar, rest}
+
+        ")" <> rest ->
+          {:rpar, rest}
+
+        "[" <> rest ->
+          {:lbrack, rest}
+
+        "]" <> rest ->
+          {:rbrack, rest}
+
+        "," <> rest ->
+          {:comma, rest}
+
+        "nat" <> rest ->
+          {:nat, rest}
+
+        str_or_num ->
+          if String.match?(str_or_num, ~r/^[0-9]+/) do
+            [num] = Regex.run(~r/^[0-9]+/, str_or_num)
+            {_, rest} = str_or_num |> String.split_at(String.length(num))
+            {{:num, String.to_integer(num)}, rest}
+          else
+            [str] = Regex.run(~r/^[a-zA-Z0-9_]+/, str_or_num)
+            {_, rest} = str_or_num |> String.split_at(String.length(str))
+            {{:var, str}, rest}
+          end
+      end
+
+    tokenize_chars(rest, [token | tokens])
+  end
+
+  defp tokenize_chars("", tokens) do
+    Enum.reverse(tokens)
+  end
+
+  @spec parse([token()]) :: exp()
+  def parse([]) do
+    {}
+  end
+
+  def parse([_ | _] = tokens) do
+    {exp, []} = parse_equation(tokens)
+    exp
+  end
+
+  defp parse_equation(tokens) do
+    {left, rest} = parse_prod(tokens)
+    loop_parse_equation(left, rest)
+  end
+
+  defp loop_parse_equation(left, tokens) do
+    case tokens do
+      [:plus | rest] ->
+        {right, rest} = parse_prod(rest)
+        loop_parse_equation({:sum, left, right}, rest)
+
+      _ ->
+        {left, tokens}
+    end
+  end
+
+  defp parse_prod(tokens) do
+    {left, rest} = parse_factor(tokens)
+    loop_parse_prod(left, rest)
+  end
+
+  defp loop_parse_prod(left, tokens) do
+    case tokens do
+      [:star | rest] ->
+        {right, rest} = parse_factor(rest)
+        loop_parse_prod({:prod, left, right}, rest)
+
+      _ ->
+        {left, tokens}
+    end
+  end
+
+  defp parse_factor(tokens) do
+    case tokens do
+      [:max | rest] -> parse_max(rest)
+      _ -> parse_primary(tokens)
+    end
+  end
+
+  defp parse_max(tokens) do
+    [:lpar, :lbrack | rest] = tokens
+    {params, rest} = parse_params(rest)
+    [:rbrack, :rpar | rest] = rest
+    {{:max, params}, rest}
+  end
+
+  defp parse_params(tokens) do
+    {param, rest} = parse_equation(tokens)
+    loop_parse_params([param], rest)
+  end
+
+  defp loop_parse_params(params, tokens) do
+    case tokens do
+      [:comma | rest] ->
+        {param, rest} = parse_equation(rest)
+        loop_parse_params([param | params], rest)
+
+      _ ->
+        {params, tokens}
+    end
+  end
+
+  defp parse_primary(tokens) do
+    case tokens do
+      [{:num, n} | rest] ->
+        {{:num, n}, rest}
+
+      [:nat, :lpar, {:var, var_name}, :rpar | rest] ->
+        {{:nat, var_name}, rest}
+
+      [:nat, :lpar, {:var, var_name}, :plus, {:num, n}, :rpar | rest] ->
+        {{:nat, {:sum, var_name, n}}, rest}
+
+      [:lpar | rest] ->
+        {exp, rest} = parse_equation(rest)
+        [:rpar | rest] = rest
+        {exp, rest}
+    end
+  end
+
+  @spec evaluate(exp(), %{binary() => number()}) :: number()
+  def evaluate(tree, vars) do
+    case tree do
+      {:nat, {:sum, var, n}} -> n + Map.get(vars, var)
+      {:nat, var} -> Map.get(vars, var)
+      {:num, n} -> n
+      {:max, exps} -> exps |> Enum.map(fn e -> evaluate(e, vars) end) |> Enum.max()
+      {:sum, exp1, exp2} -> evaluate(exp1, vars) + evaluate(exp2, vars)
+      {:prod, exp1, exp2} -> evaluate(exp1, vars) * evaluate(exp2, vars)
+      _ -> exit(:bad_node)
+    end
+  end
+end

--- a/core/test/core/unit/policies/app_policy_test.exs
+++ b/core/test/core/unit/policies/app_policy_test.exs
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Copyright 2022 Giuseppe De Palma, Matteo Trentin
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 defmodule Core.Unit.Policies.AppPolicyTest do
   use ExUnit.Case, async: true

--- a/core/test/core/unit/policies/capp_policy_test.exs
+++ b/core/test/core/unit/policies/capp_policy_test.exs
@@ -1,0 +1,372 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.Policies.CappPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Adapters.Commands.Worker
+  alias Core.Domain.Policies.SchedulingPolicy
+  alias Core.Domain.Policies.Support.CappEquations
+  alias Data.Configurations.CAPP
+  alias Data.Configurations.CAPP.Block
+  alias Data.Configurations.CAPP.Tag
+  alias Data.FunctionMetadata
+  alias Data.FunctionStruct
+  alias Data.Worker
+  alias Data.Worker.Metrics
+
+  setup_all do
+    implementation = SchedulingPolicy.impl_for(%CAPP{})
+    %{impl: implementation}
+  end
+
+  describe "protocol" do
+    test "the module should be a valid implementation of the SchedulingPolicy protocol for the Data.Configurations.CAPP type",
+         %{impl: app_impl} do
+      assert Protocol.assert_impl!(SchedulingPolicy, CAPP) == :ok
+      assert app_impl != nil
+    end
+  end
+
+  describe "get_worker_latencies" do
+    test "get_worker_latencies should return the total latency associated to each worker", %{
+      impl: app_impl
+    } do
+      workers = [
+        %Worker{
+          name: :worker1,
+          resources: %Metrics{latencies: %{"example.com" => 100, "example.org" => 150}}
+        },
+        %Worker{
+          name: :worker2,
+          resources: %Metrics{latencies: %{"example.com" => 50, "example.org" => 30}}
+        }
+      ]
+
+      [w1, w2] = workers
+
+      urls = ["example.com", "example.org"]
+      equation = "nat(A) + 2 * nat(B)" |> CappEquations.tokenize() |> CappEquations.parse()
+
+      assert app_impl.get_worker_latencies(workers, urls, equation) == [{w1, 400}, {w2, 110}]
+    end
+
+    test "get_worker_latencies should use the given placeholder value when a latency can't be found for a service, on a worker",
+         %{impl: app_impl} do
+      workers = [
+        %Worker{
+          name: :worker1,
+          resources: %Metrics{latencies: %{"example.com" => 100}}
+        },
+        %Worker{
+          name: :worker2,
+          resources: %Metrics{latencies: %{"example.org" => 30}}
+        }
+      ]
+
+      [w1, w2] = workers
+
+      urls = ["example.com", "example.org"]
+      equation = "nat(A) + 2 * nat(B)" |> CappEquations.tokenize() |> CappEquations.parse()
+
+      assert app_impl.get_worker_latencies(workers, urls, equation, 1000) == [
+               {w1, 2100},
+               {w2, 1060}
+             ]
+    end
+  end
+
+  describe "is_valid?" do
+    test "is_valid? should return true when invalidate options are :infinity and the worker can host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 100,
+        resources: %Metrics{
+          memory: %{available: 128, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        hash: <<0, 0, 0>>,
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = :infinity
+      invalidate_invocations = :infinity
+      invalidate_latency = :infinity
+
+      assert app_impl.is_valid?(
+               {wrk, 500},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == true
+    end
+
+    test "is_valid? should return true when invalidate options are satisfied and the worker can host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 256, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        hash: <<0, 0, 0>>,
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = 50
+      invalidate_invocations = 1
+      invalidate_latency = 500
+
+      assert app_impl.is_valid?(
+               {wrk, 500},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == true
+    end
+
+    test "is_valid? should return false when invalidate options are :infinity and the worker can't host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 127, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        hash: <<0, 0, 0>>,
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = :infinity
+      invalidate_invocations = :infinity
+      invalidate_latency = :infinity
+
+      assert app_impl.is_valid?(
+               {wrk, 500},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == false
+    end
+
+    test "is_valid? should return false when invalidate options are not satisfied or the worker can't host the function",
+         %{impl: app_impl} do
+      wrk = %Worker{
+        name: "worker@localhost",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 128, total: 256}
+        }
+      }
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        hash: <<0, 0, 0>>,
+        metadata: %FunctionMetadata{
+          capacity: 128
+        }
+      }
+
+      invalidate_capacity = 50
+      invalidate_invocations = 1
+      invalidate_latency = 100
+
+      assert app_impl.is_valid?(
+               {wrk |> Map.put(:resources, %Metrics{memory: %{available: 128, total: 192}}), 100},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == false
+
+      assert app_impl.is_valid?(
+               {wrk |> Map.put(:concurrent_functions, 1), 100},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == false
+
+      assert app_impl.is_valid?(
+               {wrk, 200},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == false
+
+      assert app_impl.is_valid?(
+               {wrk |> Map.put(:resources, %Metrics{memory: %{available: 127, total: 256}}), 100},
+               function,
+               invalidate_capacity,
+               invalidate_invocations,
+               invalidate_latency
+             ) == false
+    end
+  end
+
+  describe "select" do
+    setup do
+      latencies1 = %{"example.com" => 50, "example.org" => 30}
+      latencies2 = %{"example.com" => 80, "example.org" => 10}
+      latencies3 = %{"example.com" => 40, "example.org" => 40}
+
+      wrk = %Worker{
+        name: "worker@localhost",
+        long_name: "worker1",
+        concurrent_functions: 0,
+        resources: %Metrics{
+          memory: %{available: 256, total: 256}
+        }
+      }
+
+      workers = [
+        wrk |> Map.put(:resources, wrk.resources |> Map.put(:latencies, latencies1)),
+        wrk
+        |> Map.put(:resources, wrk.resources |> Map.put(:latencies, latencies2))
+        |> Map.put(:long_name, "worker2"),
+        wrk
+        |> Map.put(:resources, wrk.resources |> Map.put(:latencies, latencies3))
+        |> Map.put(:long_name, "worker3")
+      ]
+
+      script = %CAPP{
+        tags: %{
+          "test-tag" => %Tag{
+            blocks: [
+              %Block{
+                workers: "*",
+                strategy: :min_latency,
+                invalidate: %{
+                  capacity_used: :infinity,
+                  max_concurrent_invocations: :infinity,
+                  max_latency: :infinity
+                }
+              }
+            ],
+            followup: :default
+          }
+        }
+      }
+
+      equation = "nat(A) + 2*nat(B)"
+
+      function = %FunctionStruct{
+        name: "test-func",
+        module: "test-mod",
+        hash: <<0, 0, 0>>,
+        metadata: %FunctionMetadata{
+          capacity: 128,
+          tag: "test-tag",
+          miniSL_equation: equation |> CappEquations.tokenize() |> CappEquations.parse(),
+          miniSL_services: [{:get, "example.com", [], []}, {:get, "example.org", [], []}]
+        }
+      }
+
+      %{
+        workers: workers,
+        script: script,
+        function: function
+      }
+    end
+
+    test "select should return the valid worker with the minimum latency when the strategy is :min_latency",
+         %{
+           impl: app_impl,
+           workers: [wrk, wrk2, wrk3] = workers,
+           script: script,
+           function: function
+         } do
+      assert app_impl.select(script, workers, function) == {:ok, wrk2}
+
+      workers_invalid_second = [
+        wrk,
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        }),
+        wrk3
+      ]
+
+      assert app_impl.select(script, workers_invalid_second, function) == {:ok, wrk}
+
+      workers_invalid_first_second = [
+        wrk
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        }),
+        wrk2
+        |> Map.put(:resources, %Metrics{
+          memory: %{available: 0, total: 256}
+        }),
+        wrk3
+      ]
+
+      assert app_impl.select(script, workers_invalid_first_second, function) == {:ok, wrk3}
+    end
+
+    test "select should not select workers that exceed the :max_latency invalidate parameter",
+         %{
+           impl: app_impl,
+           workers: workers,
+           function: function
+         } do
+      script_invalidate = %CAPP{
+        tags: %{
+          "test-tag" => %Tag{
+            blocks: [
+              %Block{
+                workers: "*",
+                strategy: :min_latency,
+                invalidate: %{
+                  capacity_used: :infinity,
+                  max_concurrent_invocations: :infinity,
+                  max_latency: 90
+                }
+              }
+            ],
+            followup: :default
+          }
+        }
+      }
+
+      assert app_impl.select(script_invalidate, workers, function) == {:error, :no_valid_workers}
+    end
+  end
+end

--- a/core/test/core/unit/policies/parsers/capp_parser_test.exs
+++ b/core/test/core/unit/policies/parsers/capp_parser_test.exs
@@ -1,0 +1,71 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule Core.Unit.Policies.Parsers.CappParserTest do
+  use ExUnit.Case, async: true
+
+  alias Core.Domain.Policies.Parsers
+  alias Data.Configurations.CAPP
+  alias Data.Configurations.CAPP.Block
+  alias Data.Configurations.CAPP.Tag
+
+  describe "Parser" do
+    test "parse should return a valid cAPP struct when given min_latency strategy" do
+      script = File.read!("test/support/fixtures/cAPP/min_latency.yml")
+
+      assert {:ok,
+              %CAPP{
+                tags: %{
+                  "tag_a" => %Tag{
+                    blocks: [
+                      %Block{
+                        workers: ["worker1", "worker2"],
+                        invalidate: %{
+                          capacity_used: :infinity,
+                          max_concurrent_invocations: :infinity,
+                          max_latency: :infinity
+                        },
+                        strategy: :min_latency
+                      }
+                    ],
+                    followup: :fail
+                  }
+                }
+              }} == Parsers.CAPP.parse(script)
+    end
+
+    test "parse should return a valid cAPP struct when given max_latency invalidate" do
+      script = File.read!("test/support/fixtures/cAPP/max_latency.yml")
+
+      assert {:ok,
+              %CAPP{
+                tags: %{
+                  "tag_a" => %Tag{
+                    blocks: [
+                      %Block{
+                        workers: ["worker1", "worker2"],
+                        invalidate: %{
+                          capacity_used: :infinity,
+                          max_concurrent_invocations: :infinity,
+                          max_latency: 500
+                        },
+                        strategy: :"best-first"
+                      }
+                    ],
+                    followup: :fail
+                  }
+                }
+              }} == Parsers.CAPP.parse(script)
+    end
+  end
+end

--- a/core/test/core/unit/policies/support/capp_equations_test.exs
+++ b/core/test/core/unit/policies/support/capp_equations_test.exs
@@ -1,0 +1,224 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Unit.Policies.Support.CappEquationsTest do
+  use ExUnit.Case, async: true
+  alias Core.Domain.Policies.Support.CappEquations
+
+  test "tokenize" do
+    equations = [
+      "max([nat(B), nat(C)])",
+      "max([nat(A + 1), nat(B + 5)])",
+      "nat(A)+max([nat(B),nat(C)])",
+      "nat(C)+nat(A+1)*nat(B)",
+      "max([nat(A+1), nat(B)]) + 6*nat(C)",
+      "max([nat(A), nat(B)]) * nat(C) + nat(C)"
+    ]
+
+    results = [
+      [
+        :max,
+        :lpar,
+        :lbrack,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :rpar,
+        :comma,
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar,
+        :rbrack,
+        :rpar
+      ],
+      [
+        :max,
+        :lpar,
+        :lbrack,
+        :nat,
+        :lpar,
+        {:var, "A"},
+        :plus,
+        {:num, 1},
+        :rpar,
+        :comma,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :plus,
+        {:num, 5},
+        :rpar,
+        :rbrack,
+        :rpar
+      ],
+      [
+        :nat,
+        :lpar,
+        {:var, "A"},
+        :rpar,
+        :plus,
+        :max,
+        :lpar,
+        :lbrack,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :rpar,
+        :comma,
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar,
+        :rbrack,
+        :rpar
+      ],
+      [
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar,
+        :plus,
+        :nat,
+        :lpar,
+        {:var, "A"},
+        :plus,
+        {:num, 1},
+        :rpar,
+        :star,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :rpar
+      ],
+      [
+        :max,
+        :lpar,
+        :lbrack,
+        :nat,
+        :lpar,
+        {:var, "A"},
+        :plus,
+        {:num, 1},
+        :rpar,
+        :comma,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :rpar,
+        :rbrack,
+        :rpar,
+        :plus,
+        {:num, 6},
+        :star,
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar
+      ],
+      [
+        :max,
+        :lpar,
+        :lbrack,
+        :nat,
+        :lpar,
+        {:var, "A"},
+        :rpar,
+        :comma,
+        :nat,
+        :lpar,
+        {:var, "B"},
+        :rpar,
+        :rbrack,
+        :rpar,
+        :star,
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar,
+        :plus,
+        :nat,
+        :lpar,
+        {:var, "C"},
+        :rpar
+      ]
+    ]
+
+    equations
+    |> Enum.zip(results)
+    |> Enum.each(fn {eq, res} ->
+      tokens = CappEquations.tokenize(eq)
+      assert tokens == res
+    end)
+  end
+
+  test "parse" do
+    equations = [
+      "max([nat(B), nat(C)])",
+      "max([nat(A + 1), nat(B + 5)])",
+      "nat(A)+max([nat(B),nat(C)])",
+      "nat(C)+nat(A+1)*nat(B)",
+      "max([nat(A+1), nat(B)]) + 6*nat(C)",
+      "max([nat(A), nat(B)]) * nat(C) + nat(C)"
+    ]
+
+    results = [
+      {:max, [{:nat, "C"}, {:nat, "B"}]},
+      {:max, [{:nat, {:sum, "B", 5}}, {:nat, {:sum, "A", 1}}]},
+      {:sum, {:nat, "A"}, {:max, [{:nat, "C"}, {:nat, "B"}]}},
+      {:sum, {:nat, "C"}, {:prod, {:nat, {:sum, "A", 1}}, {:nat, "B"}}},
+      {:sum, {:max, [{:nat, "B"}, {:nat, {:sum, "A", 1}}]}, {:prod, {:num, 6}, {:nat, "C"}}},
+      {:sum, {:prod, {:max, [{:nat, "B"}, {:nat, "A"}]}, {:nat, "C"}}, {:nat, "C"}}
+    ]
+
+    equations
+    |> Enum.zip(results)
+    |> Enum.each(fn {eq, res} ->
+      tokens = CappEquations.tokenize(eq)
+      tree = CappEquations.parse(tokens)
+      assert tree == res
+    end)
+  end
+
+  test "evaluate" do
+    equations = [
+      "max([nat(B), nat(C)])",
+      "max([nat(A + 1), nat(B + 5)])",
+      "nat(A)+max([nat(B),nat(C)])",
+      "nat(C)+nat(A+1)*nat(B)",
+      "max([nat(A+1), nat(B)]) + 6*nat(C)",
+      "max([nat(A), nat(B)]) * nat(C) + nat(C)"
+    ]
+
+    vars = %{"A" => 5, "B" => 6, "C" => 7}
+
+    results = [
+      7,
+      11,
+      12,
+      43,
+      48,
+      49
+    ]
+
+    equations
+    |> Enum.zip(results)
+    |> Enum.each(fn {eq, res} ->
+      tokens = CappEquations.tokenize(eq)
+      tree = CappEquations.parse(tokens)
+      val = CappEquations.evaluate(tree, vars)
+      assert val == res
+    end)
+  end
+end

--- a/core/test/support/fixtures/cAPP/max_latency.yml
+++ b/core/test/support/fixtures/cAPP/max_latency.yml
@@ -1,0 +1,21 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- tag_a:
+    - workers:
+        - worker1
+        - worker2
+      strategy: best-first
+      invalidate:
+        max_latency: 500

--- a/core/test/support/fixtures/cAPP/min_latency.yml
+++ b/core/test/support/fixtures/cAPP/min_latency.yml
@@ -1,0 +1,19 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- tag_a:
+    - workers:
+        - worker1
+        - worker2
+      strategy: min_latency

--- a/data/lib/configurations/capp.ex
+++ b/data/lib/configurations/capp.ex
@@ -1,0 +1,80 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Data.Configurations.CAPP.Block do
+  @moduledoc """
+  Struct encoding a Block in a cAPP configuration script.
+  Generally used as content for %CAPP.Tag{}.
+
+  ## Fields
+  - workers: either a list of String or the single "*" String.
+             Encodes the desired workers when using this block in scheduling
+             ("*" meaning all available workers).
+  - strategy: standard APP strategy, with additional :"min-latency" allowed strategy.
+              This selects the worker with the lowest (calculated) latency among the ones available.
+  - invalidate: standard APP invalidate, with additional :max_latency key.
+                Indicates the maximum (calculated) latency allowed for the selected node.
+  """
+  @type t :: %__MODULE__{
+          strategy: :random | :"best-first" | :platform | :min_latency,
+          workers: String.t() | [String.t()],
+          invalidate: %{
+            capacity_used: number() | :infinity,
+            max_concurrent_invocations: number() | :infinity,
+            max_latency: number() | :infinity
+          }
+        }
+  defstruct [
+    :workers,
+    strategy: :"best-first",
+    invalidate: %{
+      capacity_used: :infinity,
+      max_concurrent_invocations: :infinity,
+      max_latency: :infinity
+    }
+  ]
+end
+
+defmodule Data.Configurations.CAPP.Tag do
+  @moduledoc """
+  Struct encoding a Tag in a cAPP configuration script.
+  Generally used as content for %CAPP{}.
+
+  ## Fields
+  - blocks: a list of APP.Block structs, each encoding a single block defined for the tag in the APP script.
+  - followup: either the :default or the :fail atom, extracted from the APP script.
+  """
+  @type t :: %__MODULE__{
+          blocks: [Data.Configurations.CAPP.Block.t()],
+          followup: :default | :fail
+        }
+  defstruct [:blocks, followup: :fail]
+end
+
+defmodule Data.Configurations.CAPP do
+  @moduledoc """
+  Struct encoding a cAPP configuration script.
+  Generally produced by Core.Domain.Policies.Parsers.CAPP.parse/1.
+
+  ## Fields
+  - tags: map with String keys and cAPP.Tag values.
+          Associates the name of each tag with the struct encoding the tag.
+  """
+  @type t :: %__MODULE__{
+          tags: %{
+            String.t() => Data.Configurations.CAPP.Tag
+          }
+        }
+  defstruct [:tags]
+end

--- a/data/lib/function_metadata.ex
+++ b/data/lib/function_metadata.ex
@@ -29,6 +29,8 @@ defmodule Data.FunctionMetadata do
                 Each input/output field is itself a tuple {field_name, field_type}.
                 Currently used for the miniSL language.
                 The list must contain the services in order of declaration in the function.
+    - miniSL_equation:
+                A tuple representing the (parsed) associated cost equation of a miniSL program.
   """
   @type param :: {String.t(), :int | :float | :bool | :string | :array}
   @type svc :: {:get | :post | :put | :delete, String.t(), [param()], [param()]}
@@ -38,7 +40,13 @@ defmodule Data.FunctionMetadata do
           capacity: integer(),
           params: [String.t()],
           main_func: String.t(),
-          miniSL_services: [svc()]
+          miniSL_services: [svc()],
+          miniSL_equation: tuple()
         }
-  defstruct tag: nil, capacity: -1, params: [], main_func: nil, miniSL_services: []
+  defstruct tag: nil,
+            capacity: -1,
+            params: [],
+            main_func: nil,
+            miniSL_services: [],
+            miniSL_equation: {}
 end

--- a/data/lib/function_metadata.ex
+++ b/data/lib/function_metadata.ex
@@ -20,7 +20,7 @@ defmodule Data.FunctionMetadata do
     - tag: a string containing the function's tag. Can be anything, generally used with custom scheduling policies or metrics.
     - capacity: the amount of memory this function requires to be allocated on a worker
     - params: a list of strings, representing the names of the parameters of the function, ordered
-    - main_func: the main function to be called in the function
+    - main_func: the name of the main function to be called when invoking
     - miniSL_services:
                 a list of tuples, containing the methods, URLs and request/response fields of
                 declared services.

--- a/data/lib/worker_metrics.ex
+++ b/data/lib/worker_metrics.ex
@@ -20,11 +20,13 @@ defmodule Data.Worker.Metrics do
     - cpu: percentage of cpu currently in use
     - load_avg: load average over 1, 5 and 15 minutes
     - memory: free, available and total RAM in the system
+    - latencies: map from URLs to latency of each (e.g. %{"https://example.com/" => 56})
   """
   @type t :: %__MODULE__{
           cpu: number(),
           load_avg: %{l1: number(), l5: number(), l15: number()},
-          memory: %{free: number(), available: number(), total: number()}
+          memory: %{free: number(), available: number(), total: number()},
+          latencies: %{String.t() => number()}
         }
-  defstruct [:cpu, :load_avg, :memory]
+  defstruct [:cpu, :load_avg, :memory, :latencies]
 end


### PR DESCRIPTION
This PR integrates the work done on cAPP and miniSL, i.e.:

- [ ] ~~service latency monitoring~~ (moved to future PR)
- [x] cAPP parsing
- [x] Function metadata extension (i.e. add equation)
- [x] Worker metadata extension (i.e. add service latencies)
- [x] cAPP-based cost-aware scheduling
  - [x] PUBS equation parsing
  - [x] min_strategy policy
  - [x] max_latency invalidate 