### PR TITLE
Add capp endpoints

### DIFF
--- a/core/lib/core/domain/capp_scripts.ex
+++ b/core/lib/core/domain/capp_scripts.ex
@@ -1,0 +1,132 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule Core.Domain.CAPPScripts do
+  @moduledoc """
+  The APPScripts context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Core.Repo
+
+  alias Core.Schemas.APPScripts.CAPP
+
+  @doc """
+  Returns the list of app_scripts.
+
+  ## Examples
+
+      iex> list_capp_scripts()
+      [%CAPP{}, ...]
+
+  """
+  def list_capp_scripts do
+    Repo.all(CAPP)
+  end
+
+  @doc """
+  Gets a single app_script by name.
+
+  ## Examples
+
+      iex> get_capp_script_by_name("some_name")
+      %CAPP{}
+
+      iex> get_capp_script_by_name("non_existent_name")
+      nil
+  """
+  def get_capp_script_by_name(name) do
+    Repo.get_by(CAPP, name: name)
+  end
+
+  @doc """
+  Gets a single app_script.
+
+  Raises `Ecto.NoResultsError` if the App script does not exist.
+
+  ## Examples
+
+      iex> get_capp_script!(123)
+      %CAPP{}
+
+      iex> get_capp_script!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_capp_script!(id), do: Repo.get!(CAPP, id)
+
+  @doc """
+  Creates a capp_script.
+
+  ## Examples
+
+      iex> create_capp_script(%{field: value})
+      {:ok, %CAPP{}}
+
+      iex> create_capp_script(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_capp_script(attrs \\ %{}) do
+    %CAPP{}
+    |> CAPP.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a capp_script.
+
+  ## Examples
+
+      iex> update_capp_script(app_script, %{field: new_value})
+      {:ok, %CAPP{}}
+
+      iex> update_capp_script(app_script, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_capp_script(%CAPP{} = app_script, attrs) do
+    app_script
+    |> CAPP.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a capp_script.
+
+  ## Examples
+
+      iex> delete_capp_script(app_script)
+      {:ok, %CAPP{}}
+
+      iex> delete_capp_script(app_script)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_capp_script(%CAPP{} = app_script) do
+    Repo.delete(app_script)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking app_script changes.
+
+  ## Examples
+
+      iex> change_capp_script(app_script)
+      %Ecto.Changeset{data: %CAPP{}}
+
+  """
+  def change_capp_script(%CAPP{} = app_script, attrs \\ %{}) do
+    CAPP.changeset(app_script, attrs)
+  end
+end

--- a/core/lib/core/schemas/app_scripts/capp_script.ex
+++ b/core/lib/core/schemas/app_scripts/capp_script.ex
@@ -1,0 +1,36 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Schemas.APPScripts.CAPP do
+  @moduledoc """
+  The CAPP script schema.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "capp_scripts" do
+    field(:name, :string)
+    field(:script, :map)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(capp_script, attrs) do
+    capp_script
+    |> cast(attrs, [:name, :script])
+    |> validate_required([:name, :script])
+    |> unique_constraint(:name)
+  end
+end

--- a/core/lib/core_web/controllers/capp_script_controller.ex
+++ b/core/lib/core_web/controllers/capp_script_controller.ex
@@ -1,0 +1,68 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule CoreWeb.CAPPScriptController do
+  use CoreWeb, :controller
+
+  alias Core.Domain.CAPPScripts
+  alias Core.Domain.Policies.Parsers
+  alias Core.Schemas.APPScripts.CAPP
+
+  action_fallback(CoreWeb.FallbackController)
+
+  def index(conn, _params) do
+    scripts = CAPPScripts.list_capp_scripts()
+    render(conn, :index, app_scripts: scripts)
+  end
+
+  def create(conn, %{"name" => script_name, "file" => %Plug.Upload{path: tmp_path}}) do
+    with {:ok, capp_script_string} <- File.read(tmp_path),
+         {:ok, capp_script} <- Parsers.APP.parse(capp_script_string),
+         {:ok, %CAPP{} = script} <-
+           CAPPScripts.create_capp_script(%{
+             name: script_name,
+             # TODO: change to a cAPP parser
+             script: capp_script |> Parsers.APP.to_map()
+           }) do
+      conn
+      |> put_status(:created)
+      |> render(:show, app_script: script)
+    end
+  end
+
+  def create(_, _) do
+    {:error, :bad_params}
+  end
+
+  def show(conn, %{"app_name" => name}) do
+    script = CAPPScripts.get_capp_script_by_name(name)
+    render(conn, :show, capp_script: script)
+  end
+
+  def update(conn, %{"id" => id, "capp_script" => capp_script_params}) do
+    capp_script = CAPPScripts.get_capp_script!(id)
+
+    with {:ok, %CAPP{} = capp_script} <-
+           CAPPScripts.update_capp_script(capp_script, capp_script_params) do
+      render(conn, :show, app_script: capp_script)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    script = CAPPScripts.get_capp_script!(id)
+
+    with {:ok, %CAPP{}} <- CAPPScripts.delete_capp_script(script) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/core/lib/core_web/controllers/capp_script_json.ex
+++ b/core/lib/core_web/controllers/capp_script_json.ex
@@ -1,0 +1,38 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+defmodule CoreWeb.CAPPScriptJSON do
+  alias Core.Schemas.APPScripts.CAPP
+
+  @doc """
+  Renders a list of capp_scripts.
+  """
+  def index(%{capp_scripts: capp_scripts}) do
+    %{data: for(capp_script <- capp_scripts, do: data(capp_script))}
+  end
+
+  @doc """
+  Renders a single capp_script.
+  """
+  def show(%{capp_script: capp_script}) do
+    %{data: data(capp_script)}
+  end
+
+  defp data(%CAPP{} = capp_script) do
+    %{
+      id: capp_script.id,
+      name: capp_script.name,
+      script: capp_script.script
+    }
+  end
+end

--- a/core/priv/repo/migrations/20240721142230_create_capp_scripts.exs
+++ b/core/priv/repo/migrations/20240721142230_create_capp_scripts.exs
@@ -1,0 +1,26 @@
+# Copyright 2023 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Repo.Migrations.CreateCappScripts do
+  use Ecto.Migration
+
+  def change do
+    create table(:capp_scripts) do
+      add :name, :string
+      add :script, :map
+
+      timestamps()
+    end
+  end
+end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -659,3 +659,79 @@ paths:
           $ref: "#/components/responses/null_response"
         default:
           $ref: "#/components/responses/unexpected_error"
+
+  /v1/scripts/capp:
+    # GET /capp
+    get:
+      summary: List current cAPP scripts
+      operationId: list_capp
+      description: List all cAPP scripts
+      tags:
+        - capp
+      responses:
+        "200":
+          description: An array of cAPP scripts names
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/module_names_result"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+    # POST /capp
+    post:
+      summary: Create new cAPP script
+      operationId: create_capp
+      description: Create a new cAPP script
+      tags:
+        - capp
+      requestBody:
+        description: cAPP to create
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/app_create_update"
+            encoding:
+              code:
+                contentType: application/octet-stream
+      responses:
+        "201":
+          $ref: "#/components/responses/null_response"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+  /v1/scripts/capp/{capp_name}:
+    # GET /capp/{capp}
+    get:
+      summary: Show cAPP info
+      operationId: show_capp_by_name
+      description: Get cAPP data (name, content of script)
+      tags:
+        - capp
+      parameters:
+        - $ref: "#/components/parameters/module_name"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/single_app_result"
+        default:
+          $ref: "#/components/responses/unexpected_error"
+
+      # DELETE /capp/{capp}
+    delete:
+      summary: Delete cAPP
+      operationId: delete_capp
+      description: Delete single cAPP script
+      tags:
+        - capp
+      parameters:
+        - $ref: "#/components/parameters/module_name"
+      responses:
+        "200":
+          $ref: "#/components/responses/null_response"
+        default:
+          $ref: "#/components/responses/unexpected_error"


### PR DESCRIPTION
This PR adds the CRUD endpoints for capp scripts in openapi spec and the migration, schema, context and controller to handle capp scripts in the core