### PR TITLE
Add scheduling-time upper bound computation

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -30,6 +30,8 @@ config :core, Core.Domain.Ports.Connectors.Manager, adapter: Core.Adapters.Conne
 config :core, Core.Domain.Ports.DataSinks.Manager, adapter: Core.Adapters.DataSinks.Manager
 config :core, Core.Domain.Ports.SubjectCache, adapter: Core.Adapters.Subjects.Cache
 
+config :core, Core.Domain.Ports.PubsService, adapter: Core.Adapters.PubsService
+
 config :core,
   ecto_repos: [Core.Repo, Core.SubjectsRepo]
 

--- a/core/lib/core/adapters/pubs_service/pubs_service.ex
+++ b/core/lib/core/adapters/pubs_service/pubs_service.ex
@@ -1,0 +1,31 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.PubsService do
+  @moduledoc """
+  Contacts the service exposing PUBS in the cluster.
+  Assumes a simple API that allows for both upper bound and equation computation.
+  """
+  @behaviour Core.Domain.Ports.PubsService
+
+  @impl true
+  def compute_upper_bound(_equations) do
+    {:ok, ""}
+  end
+
+  @impl true
+  def get_equation(_function_name, _function_code) do
+    {:ok, ""}
+  end
+end

--- a/core/lib/core/adapters/pubs_service/test.ex
+++ b/core/lib/core/adapters/pubs_service/test.ex
@@ -1,0 +1,28 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Adapters.PubsService.Test do
+  @moduledoc false
+  @behaviour Core.Domain.Ports.PubsService
+
+  @impl true
+  def compute_upper_bound(_) do
+    {:ok, ""}
+  end
+
+  @impl true
+  def get_equation(_, _) do
+    {:ok, ""}
+  end
+end

--- a/core/lib/core/domain/invoker.ex
+++ b/core/lib/core/domain/invoker.ex
@@ -68,7 +68,7 @@ defmodule Core.Domain.Invoker do
           metadata: struct(FunctionMetadata, %{tag: metadata.tag, capacity: metadata.capacity})
         })
 
-      with {:ok, worker} <- Nodes.worker_nodes() |> Scheduler.select(func, ivk.config) do
+      with {:ok, worker} <- Nodes.worker_nodes() |> Scheduler.select(func, ivk.config, ivk.args) do
         update_concurrent(worker, +1)
 
         out =

--- a/core/lib/core/domain/policies/default.ex
+++ b/core/lib/core/domain/policies/default.ex
@@ -20,10 +20,13 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.Empty do
   # since otherwise in situations where e.g. Prometheus is down, we would always have no workers
   @spec select(Empty.t(), [Data.Worker.t()], Data.FunctionStruct.t()) ::
           {:ok, Data.Worker.t()} | {:error, :no_workers} | {:error, :no_valid_workers}
+  def select(config, workers, function, args \\ %{})
+
   def select(
         %Empty{},
         [_ | _] = workers,
-        %Data.FunctionStruct{metadata: %Data.FunctionMetadata{capacity: c}}
+        %Data.FunctionStruct{metadata: %Data.FunctionMetadata{capacity: c}},
+        _
       ) do
     selected_worker =
       workers
@@ -45,11 +48,11 @@ defimpl Core.Domain.Policies.SchedulingPolicy, for: Data.Configurations.Empty do
     end
   end
 
-  def select(%Empty{}, _, %Data.FunctionStruct{metadata: nil}) do
+  def select(%Empty{}, _, %Data.FunctionStruct{metadata: nil}, _) do
     {:error, :no_function_metadata}
   end
 
-  def select(%Empty{}, [], _) do
+  def select(%Empty{}, [], _, _) do
     {:error, :no_workers}
   end
 end

--- a/core/lib/core/domain/policies/scheduling_policy.ex
+++ b/core/lib/core/domain/policies/scheduling_policy.ex
@@ -21,7 +21,7 @@ defprotocol Core.Domain.Policies.SchedulingPolicy do
   @doc """
     Should select a worker from a list of workers, given a specific configuration.
   """
-  @spec select(t, [Data.Worker.t()], Data.FunctionStruct.t()) ::
+  @spec select(t, [Data.Worker.t()], Data.FunctionStruct.t(), map()) ::
           {:ok, Data.Worker.t()} | {:error, any}
-  def select(configuration, workers, function)
+  def select(configuration, workers, function, args)
 end

--- a/core/lib/core/domain/ports/pubs_service.ex
+++ b/core/lib/core/domain/ports/pubs_service.ex
@@ -1,0 +1,34 @@
+# Copyright 2024 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Core.Domain.Ports.PubsService do
+  @moduledoc """
+  Port for contacting the service exposing PUBS from the cluster.
+  """
+  @adapter :core |> Application.compile_env!(__MODULE__) |> Keyword.fetch!(:adapter)
+  @callback compute_upper_bound([String.t()]) ::
+              {:ok, String.t()} | {:error, any()}
+  @callback get_equation(String.t(), String.t()) ::
+              {:ok, String.t()} | {:error, any()}
+
+  @doc """
+  """
+  @spec compute_upper_bound([String.t()]) :: {:ok, String.t()} | {:error, any()}
+  defdelegate compute_upper_bound(equations), to: @adapter
+
+  @doc """
+  """
+  @spec get_equation(String.t(), String.t()) :: {:ok, String.t()} | {:error, any()}
+  defdelegate get_equation(name, code), to: @adapter
+end

--- a/core/lib/core/domain/scheduler.ex
+++ b/core/lib/core/domain/scheduler.ex
@@ -36,7 +36,7 @@ defmodule Core.Domain.Scheduler do
 
   # NOTE: if we move this to a NIF, we should only pass
   # configuration information (to avoid serialising all parameters)
-  def select(workers, function, config) do
+  def select(workers, function, config, args \\ %{}) do
     Logger.info("Scheduler: selection with #{length(workers)} workers")
 
     # Get the resources
@@ -54,7 +54,8 @@ defmodule Core.Domain.Scheduler do
         case SchedulingPolicy.select(
                config,
                resources,
-               function
+               function,
+               args
              ) do
           {:ok, wrk} -> {:ok, wrk.name}
           {:error, err} -> {:error, err}

--- a/data/lib/function_metadata.ex
+++ b/data/lib/function_metadata.ex
@@ -30,7 +30,7 @@ defmodule Data.FunctionMetadata do
                 Currently used for the miniSL language.
                 The list must contain the services in order of declaration in the function.
     - miniSL_equation:
-                A tuple representing the (parsed) associated cost equation of a miniSL program.
+                An array of strings, containing the function's equations (ordered).
   """
   @type param :: {String.t(), :int | :float | :bool | :string | :array}
   @type svc :: {:get | :post | :put | :delete, String.t(), [param()], [param()]}
@@ -41,7 +41,7 @@ defmodule Data.FunctionMetadata do
           params: [String.t()],
           main_func: String.t(),
           miniSL_services: [svc()],
-          miniSL_equation: tuple()
+          miniSL_equation: [String.t()]
         }
   defstruct tag: nil,
             capacity: -1,


### PR DESCRIPTION
This PR adds scheduling-time upper bound computation for cAPP functions.
Specifically, it adds a port to communicate with PUBS (deployed as a service alongside FL); it also changes function's metadata to include an array of equations.

It also changes the SchedulingPolicy protocol to include invocation parameters as part of its input.